### PR TITLE
Fix token counter overlapping model selector dropdown

### DIFF
--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -318,10 +318,15 @@
 			if (!this.usageLine) return;
 			const modelSelector = document.querySelector(CC.DOM.MODEL_SELECTOR_DROPDOWN);
 			if (!modelSelector) return;
-			const selectorLine = modelSelector.parentElement?.parentElement;
-			if (!selectorLine) return;
-			if (selectorLine.nextElementSibling !== this.usageLine) {
-				selectorLine.after(this.usageLine);
+
+			// We need to inject AFTER the toolbar, not inside it.
+			// Toolbar structure: Toolbar(flex) > div > div > Button(active)
+			const toolbar = modelSelector.closest('.relative.flex.gap-2.w-full.items-center') || 
+			                modelSelector.parentElement?.parentElement?.parentElement;
+
+			if (!toolbar) return;
+			if (toolbar.nextElementSibling !== this.usageLine) {
+				toolbar.after(this.usageLine);
 			}
 			this.refreshProgressChrome();
 		}


### PR DESCRIPTION
Fixes #2 

Description: This PR fixes a layout issue where the token counter (usage row) was being injected inside the model selector toolbar instead of below it.

The Issue: The previous selector modelSelector.parentElement?.parentElement was targeting the flex-row container (.relative.flex.gap-2.w-full.items-center) that holds the model selector buttons. Inserting the full-width usage row into this flex container caused it to try and sit alongside the buttons, breaking the layout and pushing elements out of position.

The Fix: Updated attachUsageLine() in src/content/ui.js to correctly identify the toolbar container by:

Using .closest() to find the specific toolbar class.
Falling back to a 3-level parent traversal (up from 2) to ensure we escape the flex-row.
This ensures the usage row is injected as a sibling after the toolbar, stacking vertically as intended.