### PR TITLE
feat: show seconds in countdown when less than 1 minute remaining

### DIFF
--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -10,16 +10,24 @@
 	}
 
 	function formatResetCountdown(timestampMs) {
+		// <= 0: reset time reached
 		const diffMs = timestampMs - Date.now();
-		if (diffMs <= 0) return '0m';
+		if (diffMs <= 0) return '0s';
 
-		const totalMinutes = Math.round(diffMs / (1000 * 60));
+		// < 1 min: show seconds
+		const totalSecond = Math.floor(diffMs / 1000);
+		if (totalSecond < 60) return `${totalSecond}s`;
+
+		// < 1 hour: show minutes
+		const totalMinutes = Math.round(totalSecond / 60);
 		if (totalMinutes < 60) return `${totalMinutes}m`;
 
+		// < 1 day: show hours
 		const hours = Math.floor(totalMinutes / 60);
 		const minutes = totalMinutes % 60;
 		if (hours < 24) return `${hours}h ${minutes}m`;
 
+		// >= 1 day: show days
 		const days = Math.floor(hours / 24);
 		const remHours = hours % 24;
 		return `${days}d ${remHours}h`;

--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -15,11 +15,11 @@
 		if (diffMs <= 0) return '0s';
 
 		// < 1 min: show seconds
-		const totalSecond = Math.floor(diffMs / 1000);
-		if (totalSecond < 60) return `${totalSecond}s`;
+		const totalSeconds = Math.floor(diffMs / 1000);
+		if (totalSeconds < 60) return `${totalSeconds}s`;
 
 		// < 1 hour: show minutes
-		const totalMinutes = Math.round(totalSecond / 60);
+		const totalMinutes = Math.round(totalSeconds / 60);
 		if (totalMinutes < 60) return `${totalMinutes}m`;
 
 		// < 1 day: show hours

--- a/userscript/claude-counter.user.js
+++ b/userscript/claude-counter.user.js
@@ -399,16 +399,24 @@
 	}
 
 	function formatResetCountdown(timestampMs) {
+		// <= 0: reset time reached
 		const diffMs = timestampMs - Date.now();
-		if (diffMs <= 0) return '0m';
+		if (diffMs <= 0) return '0s';
 
-		const totalMinutes = Math.round(diffMs / (1000 * 60));
+		// < 1 min: show seconds
+		const totalSeconds = Math.floor(diffMs / 1000);
+		if (totalSeconds < 60) return `${totalSeconds}s`;
+
+		// < 1 hour: show minutes
+		const totalMinutes = Math.round(totalSeconds / 60);
 		if (totalMinutes < 60) return `${totalMinutes}m`;
 
+		// < 1 day: show hours
 		const hours = Math.floor(totalMinutes / 60);
 		const minutes = totalMinutes % 60;
 		if (hours < 24) return `${hours}h ${minutes}m`;
 
+		// >= 1 day: show days
 		const days = Math.floor(hours / 24);
 		const remHours = hours % 24;
 		return `${days}d ${remHours}h`;


### PR DESCRIPTION
What: Display seconds (e.g. 48s) instead of rounded minutes when the reset countdown is under 1 minute.

Why: The original behavior rounds 45 seconds up to 1m, which feels inaccurate in the final stretch. Showing seconds gives users a clearer sense of exactly when the reset happens.