### PR TITLE
feat: browser notifications for session/weekly usage thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A minimal browser extension that shows token count, cache timer, and usage bars 
 - **Token count** — Approximate token count for the current conversation, with a mini progress bar against the 200k context limit
 - **Cache timer** — Countdown showing how long the conversation remains cached (cheaper to continue)
 - **Usage bars** — Session (5-hour) and weekly (7-day) usage from Claude's native API, with progress bars and reset countdowns (more accurate than the rounded /usage page)
+- **Usage notifications** — Browser notifications at 50%, 75%, 90%, 95%, and 100% usage with a 🔔 toggle to enable/disable.
 
 ## Installation
 

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,7 @@
     }
   },
   "description": "Shows ~token count, cache timer, and native session/weekly usage bars on claude.ai.",
+  "permissions": ["storage", "notifications"],
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",
@@ -37,6 +38,7 @@
         "src/content/bridge-client.js",
         "src/vendor/o200k_base.js",
         "src/content/tokens.js",
+        "src/notifications.js",
         "src/content/ui.js",
         "src/content/main.js"
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,9 @@
   },
   "description": "Shows ~token count, cache timer, and native session/weekly usage bars on claude.ai.",
   "permissions": ["storage", "notifications"],
+  "background": {
+    "service_worker": "src/background.js"
+  },
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,10 @@
+chrome.runtime.onMessage.addListener((msg) => {
+    if (msg.type !== 'cc:notify') return;
+    chrome.notifications.create({
+        type: 'basic',
+        iconUrl: chrome.runtime.getURL('icons/icon48.png'),
+        title: msg.title,
+        message: msg.body,
+        priority: 2,
+    });
+});

--- a/src/content/main.js
+++ b/src/content/main.js
@@ -148,6 +148,14 @@
 		usageResetMs.five_hour = normalized.five_hour?.resets_at ? Date.parse(normalized.five_hour.resets_at) : null;
 		usageResetMs.seven_day = normalized.seven_day?.resets_at ? Date.parse(normalized.seven_day.resets_at) : null;
 		ui.setUsage(normalized);
+
+		// Fire notifications if thresholds are crossed
+		if (CC.notifications) {
+			if (normalized.five_hour?.utilization != null)
+				CC.notifications.notifyIfNeeded('session', normalized.five_hour.utilization, usageResetMs.five_hour);
+			if (normalized.seven_day?.utilization != null)
+				CC.notifications.notifyIfNeeded('weekly', normalized.seven_day.utilization, usageResetMs.seven_day);
+		}
 	}
 
 	function updateOrgIdIfNeeded(newOrgId) {

--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -126,6 +126,7 @@
 			this.refreshingUsage = false;
 
 			this.domObserver = null;
+			this.notifyBtn = null;
 		}
 
 		getProgressChrome() {
@@ -180,6 +181,11 @@
 			this._setupTooltips();
 			this._observeDom();
 			this._observeTheme();
+
+			// Wire up the bell toggle — CC.notifications is loaded before ui.js
+			if (CC.notifications) {
+				CC.notifications.onToggle((enabled) => this.updateNotifyButton(enabled));
+			}
 		}
 
 		_observeTheme() {
@@ -260,9 +266,21 @@
 			this.usageLine.appendChild(this.sessionGroup);
 			this.usageLine.appendChild(this.weeklyGroup);
 
+			// Bell toggle button — click to enable/disable notifications
+			this.notifyBtn = document.createElement('button');
+			this.notifyBtn.className = 'cc-notifyBtn';
+			this.notifyBtn.title = 'Toggle usage notifications';
+			this.notifyBtn.textContent = '🔔';
+			this.notifyBtn.addEventListener('click', async (e) => {
+				e.stopPropagation(); // don't trigger the usage-refresh click
+				if (CC.notifications) await CC.notifications.toggle();
+			});
+			this.usageLine.appendChild(this.notifyBtn);
+
 			this.refreshProgressChrome();
 
-			this.usageLine.addEventListener('click', async () => {
+			this.usageLine.addEventListener('click', async (e) => {
+				if (e.target.closest('.cc-notifyBtn')) return; // handled above
 				if (!this.onUsageRefresh || this.refreshingUsage) return;
 				this.refreshingUsage = true;
 				this.usageLine.classList.add('cc-usageRow--dim');
@@ -273,6 +291,15 @@
 					this.refreshingUsage = false;
 				}
 			});
+		}
+
+		updateNotifyButton(enabled) {
+			if (!this.notifyBtn) return;
+			this.notifyBtn.textContent = enabled ? '🔔' : '🔕';
+			this.notifyBtn.title = enabled
+				? 'Notifications on — click to disable'
+				: 'Notifications off — click to enable';
+			this.notifyBtn.classList.toggle('cc-notifyBtn--off', !enabled);
 		}
 
 		_setupTooltips() {

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -44,30 +44,18 @@
 
 	// ── fire a notification ──────────────────────────────────────────────────
 
-	function fire(type, pct, resetMs) {
-		const label   = type === 'session' ? 'Session (5h)' : 'Weekly';
-		const remaining = Math.max(0, 100 - pct).toFixed(0);
-		const resetIn   = resetMs ? formatMs(resetMs - Date.now()) : null;
+function fire(type, pct, resetMs) {
+    const label = type === 'session' ? 'Session (5h)' : 'Weekly';
+    const remaining = Math.max(0, 100 - pct).toFixed(0);
+    const resetIn = resetMs ? formatMs(resetMs - Date.now()) : null;
 
-		const title = `⚠️ Claude ${label} usage: ${Math.round(pct)}%`;
-		const body  = pct >= 100
-			? (resetIn ? `Limit reached — resets in ${resetIn}` : 'Limit reached for this window.')
-			: `${remaining}% remaining` + (resetIn ? ` — resets in ${resetIn}` : '');
+    const title = `⚠️ Claude ${label} usage: ${Math.round(pct)}%`;
+    const body = pct >= 100
+        ? (resetIn ? `Limit reached — resets in ${resetIn}` : 'Limit reached.')
+        : `${remaining}% remaining` + (resetIn ? ` — resets in ${resetIn}` : '');
 
-		// MV3 extensions: use chrome.notifications
-		if (typeof chrome !== 'undefined' && chrome.notifications?.create) {
-			chrome.notifications.create(`cc_${type}_${pct}`, {
-				type:     'basic',
-				iconUrl:  chrome.runtime.getURL('icons/icon48.png'),
-				title,
-				message:  body,
-				priority: pct >= 100 ? 2 : 1,
-			});
-		} else {
-			// Fallback: Web Notifications API
-			new Notification(title, { body });
-		}
-	}
+    chrome.runtime.sendMessage({ type: 'cc:notify', title, body });
+} 
 
 	// ── main notify function ─────────────────────────────────────────────────
 

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -1,0 +1,137 @@
+(() => {
+	'use strict';
+
+	const CC = (globalThis.ClaudeCounter = globalThis.ClaudeCounter || {});
+
+	const STORAGE_KEY_ENABLED  = 'cc_notify_enabled';
+	const STORAGE_KEY_NOTIFIED = 'cc_notified_';   // + 'session' or 'weekly'
+	const STORAGE_KEY_WINDOW   = 'cc_window_';     // + 'session' or 'weekly'
+
+	const THRESHOLDS = [50, 75, 90, 95, 100]; // % values to fire at
+
+	const WINDOW_MS = {
+		session: 5 * 60 * 60 * 1000,       // 5 hours
+		weekly:  7 * 24 * 60 * 60 * 1000,   // 7 days
+	};
+
+	// ── helpers ──────────────────────────────────────────────────────────────
+
+	function formatMs(ms) {
+		if (ms <= 0) return 'now';
+		const totalMin = Math.floor(ms / 60000);
+		const h = Math.floor(totalMin / 60);
+		const m = totalMin % 60;
+		return h > 0 ? `${h}h ${m}m` : `${m}m`;
+	}
+
+	async function getEnabled() {
+		try {
+			const data = await chrome.storage.local.get(STORAGE_KEY_ENABLED);
+			// Default: enabled (true) unless explicitly set to false
+			return data[STORAGE_KEY_ENABLED] !== false;
+		} catch {
+			return true;
+		}
+	}
+
+	// ── permission request ───────────────────────────────────────────────────
+
+	function requestPermission() {
+		if (typeof Notification !== 'undefined' && Notification.permission === 'default') {
+			Notification.requestPermission();
+		}
+	}
+
+	// ── fire a notification ──────────────────────────────────────────────────
+
+	function fire(type, pct, resetMs) {
+		const label   = type === 'session' ? 'Session (5h)' : 'Weekly';
+		const remaining = Math.max(0, 100 - pct).toFixed(0);
+		const resetIn   = resetMs ? formatMs(resetMs - Date.now()) : null;
+
+		const title = `⚠️ Claude ${label} usage: ${Math.round(pct)}%`;
+		const body  = pct >= 100
+			? (resetIn ? `Limit reached — resets in ${resetIn}` : 'Limit reached for this window.')
+			: `${remaining}% remaining` + (resetIn ? ` — resets in ${resetIn}` : '');
+
+		// MV3 extensions: use chrome.notifications
+		if (typeof chrome !== 'undefined' && chrome.notifications?.create) {
+			chrome.notifications.create(`cc_${type}_${pct}`, {
+				type:     'basic',
+				iconUrl:  chrome.runtime.getURL('icons/icon48.png'),
+				title,
+				message:  body,
+				priority: pct >= 100 ? 2 : 1,
+			});
+		} else {
+			// Fallback: Web Notifications API
+			new Notification(title, { body });
+		}
+	}
+
+	// ── main notify function ─────────────────────────────────────────────────
+
+	async function notifyIfNeeded(type, pct, resetMs) {
+		if (typeof pct !== 'number' || isNaN(pct)) return;
+
+		// Check user toggle
+		const enabled = await getEnabled();
+		if (!enabled) return;
+
+		// Check browser permission
+		if (typeof Notification !== 'undefined' && Notification.permission !== 'granted') return;
+
+		const notifiedKey = STORAGE_KEY_NOTIFIED + type;
+		const windowKey   = STORAGE_KEY_WINDOW + type;
+
+		// Derive window start from reset time
+		const windowDuration = WINDOW_MS[type] ?? WINDOW_MS.session;
+		const windowStart    = resetMs ? resetMs - windowDuration : null;
+
+		let stored = {};
+		try {
+			stored = await chrome.storage.local.get([notifiedKey, windowKey]);
+		} catch {
+			return;
+		}
+
+		// New window → reset which thresholds we've notified
+		if (windowStart !== null && stored[windowKey] !== windowStart) {
+			await chrome.storage.local.set({ [notifiedKey]: 0, [windowKey]: windowStart });
+			stored[notifiedKey] = 0;
+		}
+
+		const lastNotified = stored[notifiedKey] ?? 0;
+
+		// Find highest un-notified threshold that's been crossed
+		const hit = [...THRESHOLDS].reverse().find(t => pct >= t && lastNotified < t);
+		if (hit === undefined) return;
+
+		fire(type, pct, resetMs);
+		await chrome.storage.local.set({ [notifiedKey]: hit });
+	}
+
+	// ── toggle ───────────────────────────────────────────────────────────────
+
+	let _onToggleCallback = null;
+
+	async function toggle() {
+		const wasEnabled = await getEnabled();
+		const nowEnabled = !wasEnabled;
+		await chrome.storage.local.set({ [STORAGE_KEY_ENABLED]: nowEnabled });
+		if (nowEnabled) requestPermission();
+		if (_onToggleCallback) _onToggleCallback(nowEnabled);
+		return nowEnabled;
+	}
+
+	// Call this once from ui.js to get notified when toggle changes
+	function onToggle(cb) {
+		_onToggleCallback = cb;
+		// Also call immediately with current state so the button renders correctly
+		getEnabled().then(cb);
+	}
+
+	// ── export ───────────────────────────────────────────────────────────────
+
+	CC.notifications = { notifyIfNeeded, toggle, onToggle, requestPermission, getEnabled };
+})();

--- a/src/styles.css
+++ b/src/styles.css
@@ -125,3 +125,26 @@
 .cc-hidden {
 	display: none !important;
 }
+
+/* Notification bell toggle */
+.cc-notifyBtn {
+	background: none;
+	border: none;
+	cursor: pointer;
+	padding: 0 2px;
+	font-size: 11px;
+	line-height: 1;
+	opacity: 0.55;
+	transition: opacity 150ms ease, transform 100ms ease;
+	flex-shrink: 0;
+}
+
+.cc-notifyBtn:hover {
+	opacity: 1;
+	transform: scale(1.15);
+}
+
+.cc-notifyBtn--off {
+	opacity: 0.25;
+	filter: grayscale(1);
+}


### PR DESCRIPTION
## What this adds
Fires a browser notification when Claude usage crosses 50%, 75%, 90%, 95%, and 100% of your session (5h) or weekly window — so you never waste remaining quota before it resets.

## Changes
- `manifest.json` — added `notifications`, `storage` permissions and background service worker
- `src/background.js` — new service worker that handles chrome.notifications
- `src/notifications.js` — self-contained notification module with toggle support
- `src/content/ui.js` — 🔔 bell toggle button in the usage bar to enable/disable
- `src/content/main.js` — calls notifyIfNeeded on every usage update
- `src/styles.css` — bell button styles

## Behaviour
- Each threshold fires once per window, no spam on page reload
- Bell toggle persists across sessions via chrome.storage.local
- macOS users need to enable Chrome notifications in System Settings → Notifications → Google Chrome