### PR TITLE
feat: browser notifications for session/weekly usage thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A minimal browser extension that shows token count, cache timer, and usage bars 
 
 ## Features
 
-- **Token count** — Approximate token count for the current conversation, with a mini progress bar against the 200k context limit
-- **Cache timer** — Countdown showing how long the conversation remains cached (cheaper to continue)
-- **Usage bars** — Session (5-hour) and weekly (7-day) usage from Claude's native API, with progress bars and reset countdowns (more accurate than the rounded /usage page)
-- **Usage notifications** — Browser notifications at 50%, 75%, 90%, 95%, and 100% usage with a 🔔 toggle to enable/disable.
+- **Usage notifications** — Browser notifications when session or weekly usage crosses 50%, 75%, and 90%
+- **Reset countdown alerts** — Notified 1 hour and 30 minutes before your session resets if you still have capacity remaining (skipped if usage is above 90%)
+- **Session reset alert** — Notified when your session resets so you know you have 100% available again
+- **Bell toggle** 🔔 — Click to enable/disable notifications, persists across sessions
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A minimal browser extension that shows token count, cache timer, and usage bars 
 - **Token count** — Approximate token count for the current conversation, with a mini progress bar against the 200k context limit
 - **Cache timer** — Countdown showing how long the conversation remains cached (cheaper to continue)
 - **Usage bars** — Session (5-hour) and weekly (7-day) usage from Claude's native API, with progress bars and reset countdowns (more accurate than the rounded /usage page)
+- **Usage notifications** — Browser notifications at 50%, 75%, 90%, 95%, and 100% usage with a 🔔 toggle to enable/disable.
 
 ## Installation
 

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,7 @@
     }
   },
   "description": "Shows ~token count, cache timer, and native session/weekly usage bars on claude.ai.",
+  "permissions": ["storage", "notifications"],
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",
@@ -37,6 +38,7 @@
         "src/content/bridge-client.js",
         "src/vendor/o200k_base.js",
         "src/content/tokens.js",
+        "src/notifications.js",
         "src/content/ui.js",
         "src/content/main.js"
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,9 @@
   },
   "description": "Shows ~token count, cache timer, and native session/weekly usage bars on claude.ai.",
   "permissions": ["storage", "notifications"],
+  "background": {
+    "service_worker": "src/background.js"
+  },
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,10 @@
+chrome.runtime.onMessage.addListener((msg) => {
+    if (msg.type !== 'cc:notify') return;
+    chrome.notifications.create({
+        type: 'basic',
+        iconUrl: chrome.runtime.getURL('icons/icon48.png'),
+        title: msg.title,
+        message: msg.body,
+        priority: 2,
+    });
+});

--- a/src/content/main.js
+++ b/src/content/main.js
@@ -148,6 +148,14 @@
 		usageResetMs.five_hour = normalized.five_hour?.resets_at ? Date.parse(normalized.five_hour.resets_at) : null;
 		usageResetMs.seven_day = normalized.seven_day?.resets_at ? Date.parse(normalized.seven_day.resets_at) : null;
 		ui.setUsage(normalized);
+
+		// Fire notifications if thresholds are crossed
+		if (CC.notifications) {
+			if (normalized.five_hour?.utilization != null)
+				CC.notifications.notifyIfNeeded('session', normalized.five_hour.utilization, usageResetMs.five_hour);
+			if (normalized.seven_day?.utilization != null)
+				CC.notifications.notifyIfNeeded('weekly', normalized.seven_day.utilization, usageResetMs.seven_day);
+		}
 	}
 
 	function updateOrgIdIfNeeded(newOrgId) {

--- a/src/content/main.js
+++ b/src/content/main.js
@@ -21,12 +21,6 @@
 		}
 	}
 
-	/**
-	 * Wait for an element to appear in the DOM using MutationObserver.
-	 * More efficient than polling - reacts immediately when element appears.
-	 * @param {string} selector - CSS selector
-	 * @param {number} [timeoutMs] - Optional timeout in ms. Returns null if timeout expires.
-	 */
 	function waitForElement(selector, timeoutMs) {
 		return new Promise((resolve) => {
 			const existing = document.querySelector(selector);
@@ -69,9 +63,7 @@
 			}
 		};
 
-		// Listen for custom event from bridge (history methods wrapped early)
 		window.addEventListener('cc:urlchange', fireIfChanged);
-		// Also popstate for back/forward buttons
 		window.addEventListener('popstate', fireIfChanged);
 
 		return () => {
@@ -121,8 +113,8 @@
 	let currentConversationId = null;
 	let currentOrgId = null;
 
-	let usageState = null; // last snapshot
-	let usageResetMs = { five_hour: null, seven_day: null }; // cached parsed timestamps
+	let usageState = null;
+	let usageResetMs = { five_hour: null, seven_day: null };
 	let lastUsageSseMs = 0;
 	let usageFetchInFlight = false;
 	let lastUsageUpdateMs = 0;
@@ -135,7 +127,6 @@
 	});
 	ui.initialize();
 
-	// Bridge must be ready before we can make requests
 	const bridgeReady = CC.injectBridgeOnce();
 
 	function applyUsageUpdate(normalized, source) {
@@ -144,12 +135,11 @@
 		usageState = normalized;
 		lastUsageUpdateMs = now;
 		if (source === 'sse') lastUsageSseMs = now;
-		// Cache parsed timestamps to avoid Date.parse() every tick
 		usageResetMs.five_hour = normalized.five_hour?.resets_at ? Date.parse(normalized.five_hour.resets_at) : null;
 		usageResetMs.seven_day = normalized.seven_day?.resets_at ? Date.parse(normalized.seven_day.resets_at) : null;
 		ui.setUsage(normalized);
 
-		// Fire notifications if thresholds are crossed
+		// Usage threshold notifications
 		if (CC.notifications) {
 			if (normalized.five_hour?.utilization != null)
 				CC.notifications.notifyIfNeeded('session', normalized.five_hour.utilization, usageResetMs.five_hour);
@@ -229,8 +219,6 @@
 	async function handleUrlChange() {
 		currentConversationId = getConversationId();
 
-		// Attach usage line and header independently - they have different anchor elements
-		// and CHAT_MENU_TRIGGER doesn't exist on home/new pages
 		waitForElement(CC.DOM.MODEL_SELECTOR_DROPDOWN, 60000).then((el) => {
 			if (el) ui.attachUsageLine();
 		});
@@ -243,26 +231,22 @@
 			return;
 		}
 
-		// Best-effort orgId from cookie.
 		updateOrgIdIfNeeded(getOrgIdFromCookie());
 
 		await refreshConversation();
 
-		// Usage is org-level, not conversation-level. Only fetch on first load or if stale.
 		if (!usageState) await refreshUsage();
 	}
 
 	const unobserveUrl = observeUrlChanges(handleUrlChange);
 	window.addEventListener('beforeunload', unobserveUrl);
 
-	// Refresh on branch navigation - watch for the branch indicator to change
 	let branchObserver = null;
 	document.addEventListener('click', (e) => {
 		if (!currentConversationId) return;
 		const btn = e.target.closest('button[aria-label="Previous"], button[aria-label="Next"]');
 		if (!btn) return;
 
-		// Find the branch indicator span (matches "X / Y" pattern) near the clicked button
 		const container = btn.closest('.inline-flex');
 		const spans = container?.querySelectorAll('span') || [];
 		const indicator = Array.from(spans).find((s) => /^\d+\s*\/\s*\d+$/.test(s.textContent.trim()));
@@ -270,10 +254,8 @@
 
 		const originalText = indicator.textContent;
 
-		// Clean up any existing observer
 		if (branchObserver) branchObserver.disconnect();
 
-		// Watch for the indicator text to change (with cleanup timeout)
 		branchObserver = new MutationObserver(() => {
 			if (indicator.textContent !== originalText) {
 				branchObserver.disconnect();
@@ -284,7 +266,6 @@
 
 		branchObserver.observe(indicator, { childList: true, characterData: true, subtree: true });
 
-		// Clean up if nothing changes after 60 seconds
 		setTimeout(() => {
 			if (branchObserver) {
 				branchObserver.disconnect();
@@ -293,13 +274,11 @@
 		}, 60000);
 	});
 
-	// Initial attach + fetches
 	handleUrlChange();
 
 	function tick() {
 		ui.tick();
 
-		// Refresh usage when a window ends (5h / 7d). SSE won't fire at rollover unless a message is sent.
 		const now = Date.now();
 
 		if (usageResetMs.five_hour && now >= usageResetMs.five_hour && rolloverHandledForResetMs.five_hour !== usageResetMs.five_hour) {
@@ -311,15 +290,25 @@
 			refreshUsage();
 		}
 
-		// Optional hourly safety refresh.
 		const ONE_HOUR_MS = 60 * 60 * 1000;
 		const sseAge = now - lastUsageSseMs;
 		const anyAge = now - lastUsageUpdateMs;
 		if (!document.hidden && sseAge > ONE_HOUR_MS && anyAge > ONE_HOUR_MS) {
 			refreshUsage();
 		}
+
+		// Time-based and reset notifications (checked every tick)
+		if (CC.notifications && usageState) {
+			if (usageResetMs.five_hour) {
+				CC.notifications.notifyIfResetSoon('session', usageResetMs.five_hour, usageState.five_hour?.utilization ?? 100);
+				CC.notifications.notifyOnReset('session', usageResetMs.five_hour);
+			}
+			if (usageResetMs.seven_day) {
+				CC.notifications.notifyIfResetSoon('weekly', usageResetMs.seven_day, usageState.seven_day?.utilization ?? 100);
+				CC.notifications.notifyOnReset('weekly', usageResetMs.seven_day);
+			}
+		}
 	}
 
-	// Keep countdowns + markers updated.
 	setInterval(tick, 1000);
 })();

--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -126,6 +126,7 @@
 			this.refreshingUsage = false;
 
 			this.domObserver = null;
+			this.notifyBtn = null;
 		}
 
 		getProgressChrome() {
@@ -180,6 +181,11 @@
 			this._setupTooltips();
 			this._observeDom();
 			this._observeTheme();
+
+			// Wire up the bell toggle — CC.notifications is loaded before ui.js
+			if (CC.notifications) {
+				CC.notifications.onToggle((enabled) => this.updateNotifyButton(enabled));
+			}
 		}
 
 		_observeTheme() {
@@ -260,9 +266,21 @@
 			this.usageLine.appendChild(this.sessionGroup);
 			this.usageLine.appendChild(this.weeklyGroup);
 
+			// Bell toggle button — click to enable/disable notifications
+			this.notifyBtn = document.createElement('button');
+			this.notifyBtn.className = 'cc-notifyBtn';
+			this.notifyBtn.title = 'Toggle usage notifications';
+			this.notifyBtn.textContent = '🔔';
+			this.notifyBtn.addEventListener('click', async (e) => {
+				e.stopPropagation(); // don't trigger the usage-refresh click
+				if (CC.notifications) await CC.notifications.toggle();
+			});
+			this.usageLine.appendChild(this.notifyBtn);
+
 			this.refreshProgressChrome();
 
-			this.usageLine.addEventListener('click', async () => {
+			this.usageLine.addEventListener('click', async (e) => {
+				if (e.target.closest('.cc-notifyBtn')) return; // handled above
 				if (!this.onUsageRefresh || this.refreshingUsage) return;
 				this.refreshingUsage = true;
 				this.usageLine.classList.add('cc-usageRow--dim');
@@ -273,6 +291,15 @@
 					this.refreshingUsage = false;
 				}
 			});
+		}
+
+		updateNotifyButton(enabled) {
+			if (!this.notifyBtn) return;
+			this.notifyBtn.textContent = enabled ? '🔔' : '🔕';
+			this.notifyBtn.title = enabled
+				? 'Notifications on — click to disable'
+				: 'Notifications off — click to enable';
+			this.notifyBtn.classList.toggle('cc-notifyBtn--off', !enabled);
 		}
 
 		_setupTooltips() {

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -44,30 +44,18 @@
 
 	// ── fire a notification ──────────────────────────────────────────────────
 
-	function fire(type, pct, resetMs) {
-		const label   = type === 'session' ? 'Session (5h)' : 'Weekly';
-		const remaining = Math.max(0, 100 - pct).toFixed(0);
-		const resetIn   = resetMs ? formatMs(resetMs - Date.now()) : null;
+function fire(type, pct, resetMs) {
+    const label = type === 'session' ? 'Session (5h)' : 'Weekly';
+    const remaining = Math.max(0, 100 - pct).toFixed(0);
+    const resetIn = resetMs ? formatMs(resetMs - Date.now()) : null;
 
-		const title = `⚠️ Claude ${label} usage: ${Math.round(pct)}%`;
-		const body  = pct >= 100
-			? (resetIn ? `Limit reached — resets in ${resetIn}` : 'Limit reached for this window.')
-			: `${remaining}% remaining` + (resetIn ? ` — resets in ${resetIn}` : '');
+    const title = `⚠️ Claude ${label} usage: ${Math.round(pct)}%`;
+    const body = pct >= 100
+        ? (resetIn ? `Limit reached — resets in ${resetIn}` : 'Limit reached.')
+        : `${remaining}% remaining` + (resetIn ? ` — resets in ${resetIn}` : '');
 
-		// MV3 extensions: use chrome.notifications
-		if (typeof chrome !== 'undefined' && chrome.notifications?.create) {
-			chrome.notifications.create(`cc_${type}_${pct}`, {
-				type:     'basic',
-				iconUrl:  chrome.runtime.getURL('icons/icon48.png'),
-				title,
-				message:  body,
-				priority: pct >= 100 ? 2 : 1,
-			});
-		} else {
-			// Fallback: Web Notifications API
-			new Notification(title, { body });
-		}
-	}
+    chrome.runtime.sendMessage({ type: 'cc:notify', title, body });
+} 
 
 	// ── main notify function ─────────────────────────────────────────────────
 

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -4,14 +4,19 @@
 	const CC = (globalThis.ClaudeCounter = globalThis.ClaudeCounter || {});
 
 	const STORAGE_KEY_ENABLED  = 'cc_notify_enabled';
-	const STORAGE_KEY_NOTIFIED = 'cc_notified_';   // + 'session' or 'weekly'
-	const STORAGE_KEY_WINDOW   = 'cc_window_';     // + 'session' or 'weekly'
+	const STORAGE_KEY_NOTIFIED = 'cc_notified_';
+	const STORAGE_KEY_WINDOW   = 'cc_window_';
 
-	const THRESHOLDS = [50, 75, 90, 95, 100]; // % values to fire at
+	const THRESHOLDS = [50, 75, 90];
+
+	const TIME_WARNINGS_MS = [
+		60 * 60 * 1000,  // 1 hour left
+		30 * 60 * 1000,  // 30 mins left
+	];
 
 	const WINDOW_MS = {
-		session: 5 * 60 * 60 * 1000,       // 5 hours
-		weekly:  7 * 24 * 60 * 60 * 1000,   // 7 days
+		session: 5 * 60 * 60 * 1000,
+		weekly:  7 * 24 * 60 * 60 * 1000,
 	};
 
 	// ── helpers ──────────────────────────────────────────────────────────────
@@ -27,7 +32,6 @@
 	async function getEnabled() {
 		try {
 			const data = await chrome.storage.local.get(STORAGE_KEY_ENABLED);
-			// Default: enabled (true) unless explicitly set to false
 			return data[STORAGE_KEY_ENABLED] !== false;
 		} catch {
 			return true;
@@ -44,35 +48,23 @@
 
 	// ── fire a notification ──────────────────────────────────────────────────
 
-function fire(type, pct, resetMs) {
-    const label = type === 'session' ? 'Session (5h)' : 'Weekly';
-    const remaining = Math.max(0, 100 - pct).toFixed(0);
-    const resetIn = resetMs ? formatMs(resetMs - Date.now()) : null;
+	function fire(title, body) {
+		chrome.runtime.sendMessage({ type: 'cc:notify', title, body });
+	}
 
-    const title = `⚠️ Claude ${label} usage: ${Math.round(pct)}%`;
-    const body = pct >= 100
-        ? (resetIn ? `Limit reached — resets in ${resetIn}` : 'Limit reached.')
-        : `${remaining}% remaining` + (resetIn ? ` — resets in ${resetIn}` : '');
-
-    chrome.runtime.sendMessage({ type: 'cc:notify', title, body });
-} 
-
-	// ── main notify function ─────────────────────────────────────────────────
+	// ── usage threshold notifications ────────────────────────────────────────
 
 	async function notifyIfNeeded(type, pct, resetMs) {
 		if (typeof pct !== 'number' || isNaN(pct)) return;
 
-		// Check user toggle
 		const enabled = await getEnabled();
 		if (!enabled) return;
 
-		// Check browser permission
 		if (typeof Notification !== 'undefined' && Notification.permission !== 'granted') return;
 
 		const notifiedKey = STORAGE_KEY_NOTIFIED + type;
 		const windowKey   = STORAGE_KEY_WINDOW + type;
 
-		// Derive window start from reset time
 		const windowDuration = WINDOW_MS[type] ?? WINDOW_MS.session;
 		const windowStart    = resetMs ? resetMs - windowDuration : null;
 
@@ -83,20 +75,99 @@ function fire(type, pct, resetMs) {
 			return;
 		}
 
-		// New window → reset which thresholds we've notified
 		if (windowStart !== null && stored[windowKey] !== windowStart) {
 			await chrome.storage.local.set({ [notifiedKey]: 0, [windowKey]: windowStart });
 			stored[notifiedKey] = 0;
 		}
 
 		const lastNotified = stored[notifiedKey] ?? 0;
-
-		// Find highest un-notified threshold that's been crossed
 		const hit = [...THRESHOLDS].reverse().find(t => pct >= t && lastNotified < t);
 		if (hit === undefined) return;
 
-		fire(type, pct, resetMs);
+		const label     = type === 'session' ? 'Session (5h)' : 'Weekly';
+		const remaining = Math.max(0, 100 - pct).toFixed(0);
+		const resetIn   = resetMs ? formatMs(resetMs - Date.now()) : null;
+
+		const title = `⚠️ Claude ${label} usage: ${Math.round(pct)}%`;
+		const body  = pct >= 100
+			? (resetIn ? `Limit reached — resets in ${resetIn}` : 'Limit reached.')
+			: `${remaining}% remaining` + (resetIn ? ` — resets in ${resetIn}` : '');
+
+		fire(title, body);
 		await chrome.storage.local.set({ [notifiedKey]: hit });
+	}
+
+	// ── time-based warnings (only if usage < 90%) ────────────────────────────
+
+	async function notifyIfResetSoon(type, resetMs, usagePct) {
+		if (!resetMs) return;
+		if (usagePct >= 90) return; // already near limit, skip time warnings
+
+		const enabled = await getEnabled();
+		if (!enabled) return;
+
+		if (typeof Notification !== 'undefined' && Notification.permission !== 'granted') return;
+
+		const timeLeft = resetMs - Date.now();
+		if (timeLeft <= 0) return;
+
+		const storageKey = `cc_time_warned_${type}`;
+
+		for (const warning of TIME_WARNINGS_MS) {
+			// Fire within a 60s window of the threshold
+			if (timeLeft <= warning && timeLeft > warning - 60000) {
+				let stored = {};
+				try {
+					stored = await chrome.storage.local.get(storageKey);
+				} catch {
+					return;
+				}
+				if (stored[storageKey] === warning) return; // already fired
+
+				const mins      = Math.round(timeLeft / 60000);
+				const remaining = (100 - usagePct).toFixed(0);
+				const label     = type === 'session' ? 'Session (5h)' : 'Weekly';
+
+				fire(
+					`⏰ Claude ${label} resets in ${mins} min`,
+					`You still have ${remaining}% remaining — use it before it resets!`
+				);
+				await chrome.storage.local.set({ [storageKey]: warning });
+				break;
+			}
+		}
+	}
+
+	// ── reset notification ───────────────────────────────────────────────────
+
+	async function notifyOnReset(type, resetMs) {
+		if (!resetMs) return;
+
+		const enabled = await getEnabled();
+		if (!enabled) return;
+
+		if (typeof Notification !== 'undefined' && Notification.permission !== 'granted') return;
+
+		const storageKey = `cc_reset_notified_${type}`;
+		const timeSinceReset = Date.now() - resetMs;
+
+		// Fire within 2 minutes after reset
+		if (timeSinceReset >= 0 && timeSinceReset < 2 * 60 * 1000) {
+			let stored = {};
+			try {
+				stored = await chrome.storage.local.get(storageKey);
+			} catch {
+				return;
+			}
+			if (stored[storageKey] === resetMs) return; // already fired
+
+			const label = type === 'session' ? 'Session (5h)' : 'Weekly';
+			fire(
+				`✅ Claude ${label} has reset!`,
+				`You now have 100% available — start a new conversation!`
+			);
+			await chrome.storage.local.set({ [storageKey]: resetMs });
+		}
 	}
 
 	// ── toggle ───────────────────────────────────────────────────────────────
@@ -112,14 +183,12 @@ function fire(type, pct, resetMs) {
 		return nowEnabled;
 	}
 
-	// Call this once from ui.js to get notified when toggle changes
 	function onToggle(cb) {
 		_onToggleCallback = cb;
-		// Also call immediately with current state so the button renders correctly
 		getEnabled().then(cb);
 	}
 
 	// ── export ───────────────────────────────────────────────────────────────
 
-	CC.notifications = { notifyIfNeeded, toggle, onToggle, requestPermission, getEnabled };
+	CC.notifications = { notifyIfNeeded, notifyIfResetSoon, notifyOnReset, toggle, onToggle, requestPermission, getEnabled };
 })();

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -1,0 +1,137 @@
+(() => {
+	'use strict';
+
+	const CC = (globalThis.ClaudeCounter = globalThis.ClaudeCounter || {});
+
+	const STORAGE_KEY_ENABLED  = 'cc_notify_enabled';
+	const STORAGE_KEY_NOTIFIED = 'cc_notified_';   // + 'session' or 'weekly'
+	const STORAGE_KEY_WINDOW   = 'cc_window_';     // + 'session' or 'weekly'
+
+	const THRESHOLDS = [50, 75, 90, 95, 100]; // % values to fire at
+
+	const WINDOW_MS = {
+		session: 5 * 60 * 60 * 1000,       // 5 hours
+		weekly:  7 * 24 * 60 * 60 * 1000,   // 7 days
+	};
+
+	// ── helpers ──────────────────────────────────────────────────────────────
+
+	function formatMs(ms) {
+		if (ms <= 0) return 'now';
+		const totalMin = Math.floor(ms / 60000);
+		const h = Math.floor(totalMin / 60);
+		const m = totalMin % 60;
+		return h > 0 ? `${h}h ${m}m` : `${m}m`;
+	}
+
+	async function getEnabled() {
+		try {
+			const data = await chrome.storage.local.get(STORAGE_KEY_ENABLED);
+			// Default: enabled (true) unless explicitly set to false
+			return data[STORAGE_KEY_ENABLED] !== false;
+		} catch {
+			return true;
+		}
+	}
+
+	// ── permission request ───────────────────────────────────────────────────
+
+	function requestPermission() {
+		if (typeof Notification !== 'undefined' && Notification.permission === 'default') {
+			Notification.requestPermission();
+		}
+	}
+
+	// ── fire a notification ──────────────────────────────────────────────────
+
+	function fire(type, pct, resetMs) {
+		const label   = type === 'session' ? 'Session (5h)' : 'Weekly';
+		const remaining = Math.max(0, 100 - pct).toFixed(0);
+		const resetIn   = resetMs ? formatMs(resetMs - Date.now()) : null;
+
+		const title = `⚠️ Claude ${label} usage: ${Math.round(pct)}%`;
+		const body  = pct >= 100
+			? (resetIn ? `Limit reached — resets in ${resetIn}` : 'Limit reached for this window.')
+			: `${remaining}% remaining` + (resetIn ? ` — resets in ${resetIn}` : '');
+
+		// MV3 extensions: use chrome.notifications
+		if (typeof chrome !== 'undefined' && chrome.notifications?.create) {
+			chrome.notifications.create(`cc_${type}_${pct}`, {
+				type:     'basic',
+				iconUrl:  chrome.runtime.getURL('icons/icon48.png'),
+				title,
+				message:  body,
+				priority: pct >= 100 ? 2 : 1,
+			});
+		} else {
+			// Fallback: Web Notifications API
+			new Notification(title, { body });
+		}
+	}
+
+	// ── main notify function ─────────────────────────────────────────────────
+
+	async function notifyIfNeeded(type, pct, resetMs) {
+		if (typeof pct !== 'number' || isNaN(pct)) return;
+
+		// Check user toggle
+		const enabled = await getEnabled();
+		if (!enabled) return;
+
+		// Check browser permission
+		if (typeof Notification !== 'undefined' && Notification.permission !== 'granted') return;
+
+		const notifiedKey = STORAGE_KEY_NOTIFIED + type;
+		const windowKey   = STORAGE_KEY_WINDOW + type;
+
+		// Derive window start from reset time
+		const windowDuration = WINDOW_MS[type] ?? WINDOW_MS.session;
+		const windowStart    = resetMs ? resetMs - windowDuration : null;
+
+		let stored = {};
+		try {
+			stored = await chrome.storage.local.get([notifiedKey, windowKey]);
+		} catch {
+			return;
+		}
+
+		// New window → reset which thresholds we've notified
+		if (windowStart !== null && stored[windowKey] !== windowStart) {
+			await chrome.storage.local.set({ [notifiedKey]: 0, [windowKey]: windowStart });
+			stored[notifiedKey] = 0;
+		}
+
+		const lastNotified = stored[notifiedKey] ?? 0;
+
+		// Find highest un-notified threshold that's been crossed
+		const hit = [...THRESHOLDS].reverse().find(t => pct >= t && lastNotified < t);
+		if (hit === undefined) return;
+
+		fire(type, pct, resetMs);
+		await chrome.storage.local.set({ [notifiedKey]: hit });
+	}
+
+	// ── toggle ───────────────────────────────────────────────────────────────
+
+	let _onToggleCallback = null;
+
+	async function toggle() {
+		const wasEnabled = await getEnabled();
+		const nowEnabled = !wasEnabled;
+		await chrome.storage.local.set({ [STORAGE_KEY_ENABLED]: nowEnabled });
+		if (nowEnabled) requestPermission();
+		if (_onToggleCallback) _onToggleCallback(nowEnabled);
+		return nowEnabled;
+	}
+
+	// Call this once from ui.js to get notified when toggle changes
+	function onToggle(cb) {
+		_onToggleCallback = cb;
+		// Also call immediately with current state so the button renders correctly
+		getEnabled().then(cb);
+	}
+
+	// ── export ───────────────────────────────────────────────────────────────
+
+	CC.notifications = { notifyIfNeeded, toggle, onToggle, requestPermission, getEnabled };
+})();

--- a/src/styles.css
+++ b/src/styles.css
@@ -125,3 +125,26 @@
 .cc-hidden {
 	display: none !important;
 }
+
+/* Notification bell toggle */
+.cc-notifyBtn {
+	background: none;
+	border: none;
+	cursor: pointer;
+	padding: 0 2px;
+	font-size: 11px;
+	line-height: 1;
+	opacity: 0.55;
+	transition: opacity 150ms ease, transform 100ms ease;
+	flex-shrink: 0;
+}
+
+.cc-notifyBtn:hover {
+	opacity: 1;
+	transform: scale(1.15);
+}
+
+.cc-notifyBtn--off {
+	opacity: 0.25;
+	filter: grayscale(1);
+}


### PR DESCRIPTION
## What this adds

Fires browser notifications so you never waste remaining Claude quota before a session resets.

## Notifications fired

| Trigger | Message |
|---|---|
| Usage hits 50%, 75%, 90% | ⚠️ Claude Session (5h) usage: X% — Y% remaining, resets in Zh |
| 1 hour before reset (if usage < 90%) | ⏰ Session resets in 60 min — you still have X% remaining! |
| 30 mins before reset (if usage < 90%) | ⏰ Session resets in 30 min — you still have X% remaining! |
| Session resets | ✅ Claude Session (5h) has reset! You now have 100% available |

Same set fires for weekly usage window too.

## Changes

- `manifest.json` — added `notifications`, `storage` permissions and background service worker
- `src/background.js` — new service worker that handles `chrome.notifications`
- `src/notifications.js` — self-contained notification module
- `src/content/ui.js` — 🔔 bell toggle in the usage bar to enable/disable
- `src/content/main.js` — calls notify functions on every usage update and every tick
- `src/styles.css` — bell button styles

## Behaviour

- Each threshold fires once per window — no spam on page reload
- Time warnings skipped if usage is already ≥ 90% (redundant at that point)
- Bell toggle persists across sessions via `chrome.storage.local`
- macOS: enable Chrome notifications in System Settings → Notifications → Google Chrome