### PR TITLE
fix: update DOM selectors to restore header counter after claude.ai UI changes

### DIFF
--- a/src/content/constants.js
+++ b/src/content/constants.js
@@ -4,7 +4,7 @@
 	const CC = (globalThis.ClaudeCounter = globalThis.ClaudeCounter || {});
 
 	CC.DOM = Object.freeze({
-		CHAT_MENU_TRIGGER: '[data-testid="chat-menu-trigger"]',
+		CHAT_MENU_TRIGGER: '[data-testid="chat-title-split"]',
 		MODEL_SELECTOR_DROPDOWN: '[data-testid="model-selector-dropdown"]',
 		CHAT_PROJECT_WRAPPER: '.chat-project-wrapper',
 		BRIDGE_SCRIPT_ID: 'cc-bridge-script'

--- a/src/content/ui.js
+++ b/src/content/ui.js
@@ -311,10 +311,9 @@
 		}
 
 		attachHeader() {
-			const chatMenu = document.querySelector(CC.DOM.CHAT_MENU_TRIGGER);
-			if (!chatMenu) return;
-			const anchor = chatMenu.closest(CC.DOM.CHAT_PROJECT_WRAPPER) || chatMenu.parentElement;
+			const anchor = document.querySelector(CC.DOM.CHAT_MENU_TRIGGER);
 			if (!anchor) return;
+			
 			if (anchor.nextElementSibling !== this.headerContainer) {
 				anchor.after(this.headerContainer);
 			}

--- a/userscript/claude-counter.user.js
+++ b/userscript/claude-counter.user.js
@@ -147,7 +147,7 @@
 	const CC = (globalThis.ClaudeCounter = globalThis.ClaudeCounter || {});
 
 	CC.DOM = Object.freeze({
-		CHAT_MENU_TRIGGER: '[data-testid="chat-menu-trigger"]',
+		CHAT_MENU_TRIGGER: '[data-testid="chat-title-split"]',
 		MODEL_SELECTOR_DROPDOWN: '[data-testid="model-selector-dropdown"]',
 		CHAT_PROJECT_WRAPPER: '.chat-project-wrapper',
 		BRIDGE_SCRIPT_ID: 'cc-bridge-script'
@@ -700,10 +700,9 @@
 		}
 
 		attachHeader() {
-			const chatMenu = document.querySelector(CC.DOM.CHAT_MENU_TRIGGER);
-			if (!chatMenu) return;
-			const anchor = chatMenu.closest(CC.DOM.CHAT_PROJECT_WRAPPER) || chatMenu.parentElement;
+			const anchor = document.querySelector(CC.DOM.CHAT_MENU_TRIGGER);
 			if (!anchor) return;
+			
 			if (anchor.nextElementSibling !== this.headerContainer) {
 				anchor.after(this.headerContainer);
 			}


### PR DESCRIPTION
This fixes #27, after Anthropic changed their DOM structure and removed the `[data-testid="chat-menu-trigger"]` element, which broke the header counter. 

Changes:
* Updated the trigger selector to `[data-testid="chat-title-split"]`
* Cleaned up `attachHeader()` in `ui.js`. Since `.chat-project-wrapper` is also gone, the old code was just hitting the `parentElement` fallback anyway
* Applied the same fixes to the userscript `claude-counter.user.js`

I've tested both the extension (in Firefox Developer Edition v152) and the userscript (via Tampermonkey).