### PR TITLE
Add a behavioral test suite for the token/trunk/cache logic, usage parsers, and bridge protocol

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: test
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # jsdom 30 (dev-only) requires Node >= 22.22
+        node-version: [22, 24]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/docs/active/add-test-suite/convos/20260817_finish_test_suite_branch.md
+++ b/docs/active/add-test-suite/convos/20260817_finish_test_suite_branch.md
@@ -49,3 +49,7 @@ Helpers:
 - Reviewer findings (if any actionable) — apply after they return.
 - Whether to add ESLint + Prettier as a separate branch, now that CI exists.
 - The bigger refactor this safety net was built for hasn't started yet.
+
+## Captured Tasks
+
+- [#4: Follow-ups from add-test-suite review (brittleness, coverage gaps, minor refactors)](https://github.com/danparshall/claude-counter/issues/4) — captured 2026-08-20

--- a/docs/active/add-test-suite/convos/20260817_finish_test_suite_branch.md
+++ b/docs/active/add-test-suite/convos/20260817_finish_test_suite_branch.md
@@ -1,0 +1,51 @@
+# 20260817 — Finish `add-test-suite` branch
+
+**Date:** 2026-08-17 18:33 UTC
+**Branch:** `add-test-suite`
+**Status:** Ready to open PR against `main`
+
+## Purpose of the branch
+
+Build a characterization safety net for the claude-counter Chrome extension before doing any bigger refactor of `src/content/`. The runtime code was untested; the goal was to lock current behavior in before changing it.
+
+## What landed on the branch
+
+Five commits, oldest → newest:
+
+1. `8fc0b91` — chore: add vitest test scaffolding (dev-only, no runtime changes)
+2. `bad2c40` — test: characterization suite for token/trunk/cache logic and bridge protocol
+3. `d9d9798` — refactor: expose usage parsers as `CC.parsers` for testability
+4. `5cb5837` — ci: run the test suite on push and pull request
+5. `fa5c33e` — fix: guard `buildTrunk` against cycles in the parent chain
+
+Diff scope: 15 files, +2525 / −41. Bulk is `package-lock.json` (~1700 lines) and the 4 test files (~620 lines). Runtime source touched in only two files:
+
+- `src/content/main.js` — expose parsers on the `CC` namespace so tests can import them without executing DOM-bound side effects.
+- `src/content/parsers.js` — new file, extracted from `main.js`. Behavior-preserving move.
+- `src/content/tokens.js` — cycle guard in `buildTrunk` (small, defensive; wouldn't fire on any well-formed Claude message tree).
+
+## Test suite shape
+
+Four test files, 47 tests total, all passing on Node 22 locally and on Node 22 + 24 in CI:
+
+- `tests/parsers.test.js` — usage-string parsing edge cases
+- `tests/tokens.test.js` — token counting and trunk-building
+- `tests/tokens-cache.test.js` — cache hit/miss and invalidation
+- `tests/bridge-protocol.test.js` — page-context ↔ content-script postMessage protocol
+
+Helpers:
+- `tests/helpers/load.js` — loads content-script modules into jsdom without letting them auto-init.
+- `tests/helpers/cycle-probe.cjs` — builds a synthetic cyclic message tree to exercise the `buildTrunk` guard.
+
+## What this session did
+
+- Ran `npm test` — 47/47 pass.
+- Noted absence of lint/format/typecheck config in the repo — flagged to Dan, not blocking (repo has never had it).
+- Fired two review agents in parallel: `nori-code-reviewer` on the full diff, and a testing-anti-patterns pass on the test suite. Both were still running when the PR was pushed.
+- Pushed branch and opened PR against `main`.
+
+## Open questions / follow-ups
+
+- Reviewer findings (if any actionable) — apply after they return.
+- Whether to add ESLint + Prettier as a separate branch, now that CI exists.
+- The bigger refactor this safety net was built for hasn't started yet.

--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,7 @@
     {
       "matches": ["https://claude.ai/*"],
       "css": ["src/styles.css"],
+      "_comment_js_order": "Load order matters. main.js consumes CC.constants, CC.bridge, CC.tokens, CC.parsers, and CC.ui, so all of those must load first. Underscore-prefixed keys are tolerated by Chrome and Firefox as developer metadata.",
       "js": [
         "src/content/constants.js",
         "src/content/bridge-client.js",

--- a/manifest.json
+++ b/manifest.json
@@ -37,6 +37,7 @@
         "src/content/bridge-client.js",
         "src/vendor/o200k_base.js",
         "src/content/tokens.js",
+        "src/content/parsers.js",
         "src/content/ui.js",
         "src/content/main.js"
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1700 @@
+{
+	"name": "claude-counter",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "claude-counter",
+			"devDependencies": {
+				"jsdom": "30.0.1",
+				"vitest": "4.1.10"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "6.0.7",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+			"integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/css-calc": "^3.3.0",
+				"@csstools/css-color-parser": "^4.1.10",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0",
+				"lru-cache": "^11.5.2"
+			},
+			"engines": {
+				"node": "^22.13.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+			"integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.2.1",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.5.2"
+			},
+			"engines": {
+				"node": "^22.13.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@bramus/specificity": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"css-tree": "^3.0.0"
+			},
+			"bin": {
+				"specificity": "bin/cli.js"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+			"integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+			"integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+			"integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^6.1.1",
+				"@csstools/css-calc": "^3.3.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+			"integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+			"integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.144.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+			"integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+			"integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+			"integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+			"integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+			"integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+			"integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+			"integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+			"integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+			"integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+			"integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+			"integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+			"integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+			"integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+			"integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+			"integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.10",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.10",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/data-urls": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/data-urls/node_modules/whatwg-url": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.6.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jsdom": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+			"integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^6.0.5",
+				"@asamuzakjp/dom-selector": "^8.3.0",
+				"@bramus/specificity": "^2.4.2",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+				"@exodus/bytes": "^1.15.1",
+				"css-tree": "^3.2.1",
+				"data-urls": "^7.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.5.2",
+				"parse5": "^8.0.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^6.0.2",
+				"undici": "^8.9.0",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^8.0.1",
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^17.1.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.2.3"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/lightningcss": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+			"integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.33.0",
+				"lightningcss-darwin-arm64": "1.33.0",
+				"lightningcss-darwin-x64": "1.33.0",
+				"lightningcss-freebsd-x64": "1.33.0",
+				"lightningcss-linux-arm-gnueabihf": "1.33.0",
+				"lightningcss-linux-arm64-gnu": "1.33.0",
+				"lightningcss-linux-arm64-musl": "1.33.0",
+				"lightningcss-linux-x64-gnu": "1.33.0",
+				"lightningcss-linux-x64-musl": "1.33.0",
+				"lightningcss-win32-arm64-msvc": "1.33.0",
+				"lightningcss-win32-x64-msvc": "1.33.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+			"integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+			"integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+			"integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+			"integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+			"integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+			"integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+			"integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+			"integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+			"integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+			"integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+			"integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/obug": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+			"integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.17",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rolldown": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+			"integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.144.0",
+				"@rolldown/pluginutils": "^1.0.0"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.2.4",
+				"@rolldown/binding-darwin-arm64": "1.2.4",
+				"@rolldown/binding-darwin-x64": "1.2.4",
+				"@rolldown/binding-freebsd-x64": "1.2.4",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+				"@rolldown/binding-linux-arm64-gnu": "1.2.4",
+				"@rolldown/binding-linux-arm64-musl": "1.2.4",
+				"@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+				"@rolldown/binding-linux-s390x-gnu": "1.2.4",
+				"@rolldown/binding-linux-x64-gnu": "1.2.4",
+				"@rolldown/binding-linux-x64-musl": "1.2.4",
+				"@rolldown/binding-openharmony-arm64": "1.2.4",
+				"@rolldown/binding-win32-arm64-msvc": "1.2.4",
+				"@rolldown/binding-win32-x64-msvc": "1.2.4"
+			}
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+			"integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tldts": {
+			"version": "7.4.10",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+			"integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.4.10"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "7.4.10",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+			"integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tough-cookie": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+			"integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^7.0.5"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/undici": {
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+			"integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/vite": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+			"integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.33.0",
+				"picomatch": "^4.0.5",
+				"postcss": "^8.5.25",
+				"rolldown": "~1.2.1",
+				"tinyglobby": "^0.2.17"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.4.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.10",
+				"@vitest/mocker": "4.1.10",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/runner": "4.1.10",
+				"@vitest/snapshot": "4.1.10",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.10",
+				"@vitest/browser-preview": "4.1.10",
+				"@vitest/browser-webdriverio": "4.1.10",
+				"@vitest/coverage-istanbul": "4.1.10",
+				"@vitest/coverage-v8": "4.1.10",
+				"@vitest/ui": "4.1.10",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "17.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+			"integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.15.1",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.14.0 || >=24.0.0"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "claude-counter",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"test": "vitest run"
+	},
+	"devDependencies": {
+		"jsdom": "30.0.1",
+		"vitest": "4.1.10"
+	}
+}

--- a/src/content/main.js
+++ b/src/content/main.js
@@ -80,44 +80,6 @@
 		};
 	}
 
-	function parseUsageFromUsageEndpoint(raw) {
-		if (!raw || typeof raw !== 'object') return null;
-
-		const normalizeWindow = (w, hours) => {
-			if (!w || typeof w !== 'object') return null;
-			if (typeof w.utilization !== 'number' || !Number.isFinite(w.utilization)) return null;
-			const utilization = Math.max(0, Math.min(100, w.utilization));
-			const resets_at = typeof w.resets_at === 'string' ? w.resets_at : null;
-			return { utilization, resets_at, window_hours: hours };
-		};
-
-		const fiveHour = normalizeWindow(raw.five_hour, 5);
-		const sevenDay = normalizeWindow(raw.seven_day, 24 * 7);
-
-		if (!fiveHour && !sevenDay) return null;
-		return { five_hour: fiveHour, seven_day: sevenDay };
-	}
-
-	function parseUsageFromMessageLimit(raw) {
-		if (!raw?.windows || typeof raw.windows !== 'object') return null;
-
-		const normalizeWindow = (w, hours) => {
-			if (!w || typeof w !== 'object') return null;
-			if (typeof w.utilization !== 'number' || !Number.isFinite(w.utilization)) return null;
-			const utilization = Math.max(0, Math.min(100, w.utilization * 100));
-			const resets_at = typeof w.resets_at === 'number' && Number.isFinite(w.resets_at)
-				? new Date(w.resets_at * 1000).toISOString()
-				: null;
-			return { utilization, resets_at, window_hours: hours };
-		};
-
-		const fiveHour = normalizeWindow(raw.windows['5h'], 5);
-		const sevenDay = normalizeWindow(raw.windows['7d'], 24 * 7);
-
-		if (!fiveHour && !sevenDay) return null;
-		return { five_hour: fiveHour, seven_day: sevenDay };
-	}
-
 	let currentConversationId = null;
 	let currentOrgId = null;
 
@@ -173,7 +135,7 @@
 			usageFetchInFlight = false;
 		}
 
-		const parsed = parseUsageFromUsageEndpoint(raw);
+		const parsed = CC.parsers.parseUsageFromUsageEndpoint(raw);
 		applyUsageUpdate(parsed, 'usage');
 	}
 
@@ -210,7 +172,7 @@
 	}
 
 	function handleMessageLimit(messageLimit) {
-		const parsed = parseUsageFromMessageLimit(messageLimit);
+		const parsed = CC.parsers.parseUsageFromMessageLimit(messageLimit);
 		applyUsageUpdate(parsed, 'sse');
 	}
 

--- a/src/content/parsers.js
+++ b/src/content/parsers.js
@@ -1,0 +1,45 @@
+(() => {
+	'use strict';
+
+	const CC = (globalThis.ClaudeCounter = globalThis.ClaudeCounter || {});
+
+	function parseUsageFromUsageEndpoint(raw) {
+		if (!raw || typeof raw !== 'object') return null;
+
+		const normalizeWindow = (w, hours) => {
+			if (!w || typeof w !== 'object') return null;
+			if (typeof w.utilization !== 'number' || !Number.isFinite(w.utilization)) return null;
+			const utilization = Math.max(0, Math.min(100, w.utilization));
+			const resets_at = typeof w.resets_at === 'string' ? w.resets_at : null;
+			return { utilization, resets_at, window_hours: hours };
+		};
+
+		const fiveHour = normalizeWindow(raw.five_hour, 5);
+		const sevenDay = normalizeWindow(raw.seven_day, 24 * 7);
+
+		if (!fiveHour && !sevenDay) return null;
+		return { five_hour: fiveHour, seven_day: sevenDay };
+	}
+
+	function parseUsageFromMessageLimit(raw) {
+		if (!raw?.windows || typeof raw.windows !== 'object') return null;
+
+		const normalizeWindow = (w, hours) => {
+			if (!w || typeof w !== 'object') return null;
+			if (typeof w.utilization !== 'number' || !Number.isFinite(w.utilization)) return null;
+			const utilization = Math.max(0, Math.min(100, w.utilization * 100));
+			const resets_at = typeof w.resets_at === 'number' && Number.isFinite(w.resets_at)
+				? new Date(w.resets_at * 1000).toISOString()
+				: null;
+			return { utilization, resets_at, window_hours: hours };
+		};
+
+		const fiveHour = normalizeWindow(raw.windows['5h'], 5);
+		const sevenDay = normalizeWindow(raw.windows['7d'], 24 * 7);
+
+		if (!fiveHour && !sevenDay) return null;
+		return { five_hour: fiveHour, seven_day: sevenDay };
+	}
+
+	CC.parsers = { parseUsageFromUsageEndpoint, parseUsageFromMessageLimit };
+})();

--- a/src/content/tokens.js
+++ b/src/content/tokens.js
@@ -55,8 +55,10 @@
 		if (!leaf) return [];
 
 		const trunk = [];
+		const visited = new Set();
 		let currentId = leaf;
-		while (currentId && currentId !== ROOT_MESSAGE_ID) {
+		while (currentId && currentId !== ROOT_MESSAGE_ID && !visited.has(currentId)) {
+			visited.add(currentId);
 			const msg = byId.get(currentId);
 			if (!msg) break;
 			trunk.push(msg);

--- a/tests/bridge-protocol.test.js
+++ b/tests/bridge-protocol.test.js
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+// Behavioral tests for the content-script side of the postMessage bridge
+// (src/content/bridge-client.js) against the documented wire protocol:
+//
+//   content script  -> window.postMessage({cc:'ClaudeCounter', type:'cc:request', requestId, kind, payload}, '*')
+//   page script     -> window.postMessage({cc:'ClaudeCounter', type:'cc:response', requestId, ok, payload, error}, '*')
+//   page script     -> window.postMessage({cc:'ClaudeCounter', type:'<event>', payload}, '*')  (events)
+//
+// The fake here replaces the *other process* (the injected page script), never
+// the unit under test. jsdom's window.postMessage does not set event.source
+// (known limitation), so the fake page side replies with a hand-dispatched
+// MessageEvent carrying `source: window` — exactly what a real same-window
+// postMessage delivers. That same knob lets us test the client's
+// source-filtering behavior directly.
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+await import('../src/content/constants.js');
+await import('../src/content/bridge-client.js');
+const CC = globalThis.ClaudeCounter;
+
+function reply(data, { source = window } = {}) {
+	window.dispatchEvent(new MessageEvent('message', { data, source }));
+}
+
+const installed = [];
+function onRequest(handler) {
+	const listener = (event) => {
+		const d = event.data;
+		if (!d || d.cc !== 'ClaudeCounter' || d.type !== 'cc:request') return;
+		handler(d);
+	};
+	window.addEventListener('message', listener);
+	installed.push(listener);
+}
+
+afterEach(() => {
+	while (installed.length) window.removeEventListener('message', installed.pop());
+});
+
+describe('request/response', () => {
+	it('resolves with the payload of a matching cc:response', async () => {
+		let seen; // asserted after the await — a throw inside the listener would misreport as a timeout
+		onRequest((req) => {
+			seen = req;
+			reply({ cc: 'ClaudeCounter', type: 'cc:response', requestId: req.requestId, ok: true, payload: { five_hour: 42 } });
+		});
+		const result = await CC.bridge.request('usage', { orgId: 'org-123' }, { timeoutMs: 1000 });
+		expect(seen.kind).toBe('usage');
+		expect(seen.payload).toEqual({ orgId: 'org-123' });
+		expect(result).toEqual({ five_hour: 42 });
+	});
+
+	it('rejects with the reported error when ok is false', async () => {
+		onRequest((req) => {
+			reply({ cc: 'ClaudeCounter', type: 'cc:response', requestId: req.requestId, ok: false, error: 'no such org' });
+		});
+		await expect(CC.bridge.request('usage', { orgId: 'bad' }, { timeoutMs: 1000 })).rejects.toThrow('no such org');
+	});
+
+	it('times out when the page side never answers', async () => {
+		await expect(CC.bridge.request('conversation', { conversationId: 'c1' }, { timeoutMs: 60 })).rejects.toThrow(
+			/timed out/
+		);
+	});
+
+	it('ignores responses lacking the cc marker', async () => {
+		onRequest((req) => {
+			// A same-shape message without the marker must be ignored...
+			reply({ type: 'cc:response', requestId: req.requestId, ok: true, payload: 'unmarked' });
+			// ...so the later, properly marked response is the one that wins.
+			reply({ cc: 'ClaudeCounter', type: 'cc:response', requestId: req.requestId, ok: true, payload: 'marked' });
+		});
+		const result = await CC.bridge.request('hash', { text: 'x' }, { timeoutMs: 1000 });
+		expect(result).toBe('marked');
+	});
+
+	it('ignores responses whose source is not this window', async () => {
+		onRequest((req) => {
+			reply(
+				{ cc: 'ClaudeCounter', type: 'cc:response', requestId: req.requestId, ok: true, payload: 'foreign' },
+				{ source: null }
+			);
+			reply({ cc: 'ClaudeCounter', type: 'cc:response', requestId: req.requestId, ok: true, payload: 'same-window' });
+		});
+		const result = await CC.bridge.request('hash', { text: 'y' }, { timeoutMs: 1000 });
+		expect(result).toBe('same-window');
+	});
+
+	it('ignores responses for unknown request ids', async () => {
+		onRequest((req) => {
+			reply({ cc: 'ClaudeCounter', type: 'cc:response', requestId: 'not-this-one', ok: true, payload: 'stray' });
+			reply({ cc: 'ClaudeCounter', type: 'cc:response', requestId: req.requestId, ok: true, payload: 'mine' });
+		});
+		const result = await CC.bridge.request('hash', { text: 'z' }, { timeoutMs: 1000 });
+		expect(result).toBe('mine');
+	});
+});
+
+describe('events', () => {
+	it('delivers marked event payloads to subscribed listeners', () => {
+		const received = [];
+		const unsubscribe = CC.bridge.on('cc:message_limit', (payload) => received.push(payload));
+
+		reply({ cc: 'ClaudeCounter', type: 'cc:message_limit', payload: { windows: { '5h': { utilization: 0.5 } } } });
+		expect(received).toEqual([{ windows: { '5h': { utilization: 0.5 } } }]);
+
+		reply({ type: 'cc:message_limit', payload: 'unmarked' }); // no marker -> not delivered
+		reply({ cc: 'ClaudeCounter', type: 'cc:message_limit', payload: 'foreign' }, { source: null }); // wrong source
+		expect(received).toHaveLength(1);
+
+		unsubscribe();
+		reply({ cc: 'ClaudeCounter', type: 'cc:message_limit', payload: 'after-unsubscribe' });
+		expect(received).toHaveLength(1);
+	});
+});

--- a/tests/helpers/cycle-probe.cjs
+++ b/tests/helpers/cycle-probe.cjs
@@ -1,0 +1,45 @@
+// Child-process probe for buildTrunk's behavior on a cyclic parent chain.
+//
+// buildTrunk's leaf-to-root walk is synchronous, so a cycle can't be
+// interrupted by an in-process test timeout (a busy JS loop blocks the
+// event loop, including Vitest's timers). Running the probe in a child
+// process lets the parent test kill it after a deadline instead.
+//
+// Dynamic import() (not require) so the probe works regardless of how Node
+// classifies the extension sources under the repo's "type": "module".
+//
+// Prints DONE and exits 0 if computeConversationMetrics terminates.
+
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const src = (...p) => pathToFileURL(path.join(__dirname, '..', '..', 'src', ...p));
+
+const conversation = {
+	current_leaf_message_uuid: 'aaaaaaaa-0000-4000-8000-000000000001',
+	chat_messages: [
+		{
+			uuid: 'aaaaaaaa-0000-4000-8000-000000000001',
+			parent_message_uuid: 'bbbbbbbb-0000-4000-8000-000000000002',
+			sender: 'human',
+			content: []
+		},
+		{
+			uuid: 'bbbbbbbb-0000-4000-8000-000000000002',
+			parent_message_uuid: 'aaaaaaaa-0000-4000-8000-000000000001',
+			sender: 'assistant',
+			content: []
+		}
+	]
+};
+
+(async () => {
+	await import(src('content', 'constants.js'));
+	await import(src('content', 'tokens.js'));
+	await globalThis.ClaudeCounter.tokens.computeConversationMetrics(conversation);
+	console.log('DONE');
+	process.exit(0);
+})().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/tests/helpers/load.js
+++ b/tests/helpers/load.js
@@ -1,0 +1,60 @@
+// Test loader for the extension's content scripts.
+//
+// The shipped sources are IIFEs that attach to `globalThis` (no modules, no
+// exports) — the browser loads them as plain <script>s in manifest order.
+// Tests replicate that: side-effect imports in the same relative order
+// (constants → vendor tokenizer → tokens), then exercise the public
+// `globalThis.ClaudeCounter` surface. bridge-client.js is intentionally
+// omitted — it needs `window` at import time and is covered by the
+// jsdom-env bridge-protocol tests.
+
+export const ROOT_UUID = '00000000-0000-4000-8000-000000000000';
+
+export async function loadContentScripts() {
+	await import('../../src/content/constants.js');
+	const vendor = await import('../../src/vendor/o200k_base.js');
+	// The vendor file is UMD. A plain browser <script> sets the global; some
+	// module transforms capture it as an export instead. Normalize to the
+	// global the shipped code reads (`tokens.js` looks up
+	// `globalThis.GPTTokenizer_o200k_base`).
+	if (!globalThis.GPTTokenizer_o200k_base && vendor?.default) {
+		globalThis.GPTTokenizer_o200k_base = vendor.default;
+	}
+	if (!globalThis.GPTTokenizer_o200k_base?.countTokens) {
+		throw new Error('vendored o200k tokenizer failed to load — test harness problem, not an extension bug');
+	}
+	await import('../../src/content/tokens.js');
+	return globalThis.ClaudeCounter;
+}
+
+// --- conversation payload builders (shape mirrors claude.ai's conversation API) ---
+
+export function makeMessage({
+	uuid,
+	parent = ROOT_UUID,
+	sender = 'human',
+	content = [],
+	attachments,
+	created_at
+} = {}) {
+	const msg = {
+		uuid,
+		parent_message_uuid: parent,
+		sender,
+		content
+	};
+	if (attachments !== undefined) msg.attachments = attachments;
+	if (created_at !== undefined) msg.created_at = created_at;
+	return msg;
+}
+
+export function textMessage(uuid, text, extra = {}) {
+	return makeMessage({ uuid, content: [{ type: 'text', text }], ...extra });
+}
+
+export function makeConversation(messages, leafUuid) {
+	return {
+		chat_messages: messages,
+		current_leaf_message_uuid: leafUuid
+	};
+}

--- a/tests/parsers.test.js
+++ b/tests/parsers.test.js
@@ -1,0 +1,115 @@
+// Tests for usage-payload normalization, both wire formats.
+//
+// These target CC.parsers.parseUsageFromUsageEndpoint and
+// CC.parsers.parseUsageFromMessageLimit — the two parsers extracted from
+// main.js into src/content/parsers.js so they are reachable outside the
+// orchestration IIFE (which starts observers/intervals on load and cannot
+// be imported in tests).
+
+import { describe, it, expect } from 'vitest';
+
+await import('../src/content/parsers.js');
+const parsers = globalThis.ClaudeCounter.parsers;
+
+describe('parseUsageFromUsageEndpoint (/usage REST shape)', () => {
+	const parse = (raw) => parsers.parseUsageFromUsageEndpoint(raw);
+
+	it('normalizes both windows and passes string resets_at through', () => {
+		const out = parse({
+			five_hour: { utilization: 42.5, resets_at: '2026-08-15T17:00:00Z' },
+			seven_day: { utilization: 12, resets_at: '2026-08-20T00:00:00Z' }
+		});
+		expect(out).toEqual({
+			five_hour: { utilization: 42.5, resets_at: '2026-08-15T17:00:00Z', window_hours: 5 },
+			seven_day: { utilization: 12, resets_at: '2026-08-20T00:00:00Z', window_hours: 168 }
+		});
+	});
+
+	it('clamps utilization to [0, 100]', () => {
+		expect(parse({ five_hour: { utilization: -5 } }).five_hour.utilization).toBe(0);
+		expect(parse({ five_hour: { utilization: 0 } }).five_hour.utilization).toBe(0); // 0 is valid, not "missing"
+		expect(parse({ five_hour: { utilization: 42.5 } }).five_hour.utilization).toBe(42.5);
+		expect(parse({ five_hour: { utilization: 100 } }).five_hour.utilization).toBe(100);
+		expect(parse({ five_hour: { utilization: 250 } }).five_hour.utilization).toBe(100);
+	});
+
+	it('drops a window whose utilization is non-numeric or missing', () => {
+		const out = parse({
+			five_hour: { utilization: 'lots', resets_at: '2026-08-15T17:00:00Z' },
+			seven_day: { utilization: 12 }
+		});
+		expect(out.five_hour).toBeNull();
+		expect(out.seven_day).not.toBeNull();
+		expect(parse({ five_hour: { utilization: NaN }, seven_day: { utilization: 1 } }).five_hour).toBeNull();
+		expect(parse({ five_hour: { resets_at: '2026-08-15T17:00:00Z' }, seven_day: { utilization: 1 } }).five_hour).toBeNull();
+	});
+
+	it('returns null when both windows are missing or invalid', () => {
+		expect(parse({})).toBeNull();
+		expect(parse({ five_hour: { utilization: 'x' }, seven_day: null })).toBeNull();
+		expect(parse(null)).toBeNull();
+		expect(parse('not an object')).toBeNull();
+	});
+
+	it('nulls resets_at when it is not a string', () => {
+		expect(parse({ five_hour: { utilization: 10, resets_at: 1755277200 } }).five_hour.resets_at).toBeNull();
+		expect(parse({ five_hour: { utilization: 10 } }).five_hour.resets_at).toBeNull();
+	});
+});
+
+describe('parseUsageFromMessageLimit (SSE message_limit shape)', () => {
+	const parse = (raw) => parsers.parseUsageFromMessageLimit(raw);
+
+	it('scales fractional utilization by 100 and maps 5h/7d keys', () => {
+		const out = parse({
+			windows: {
+				'5h': { utilization: 0.334, resets_at: 1700000000 },
+				'7d': { utilization: 0.5, resets_at: 1700000000 }
+			}
+		});
+		expect(out.five_hour.utilization).toBeCloseTo(33.4, 10);
+		expect(out.five_hour.window_hours).toBe(5);
+		expect(out.seven_day.utilization).toBe(50);
+		expect(out.seven_day.window_hours).toBe(168);
+	});
+
+	it('converts epoch-seconds resets_at to an ISO string', () => {
+		const out = parse({ windows: { '5h': { utilization: 0.1, resets_at: 1700000000 } } });
+		expect(out.five_hour.resets_at).toBe('2023-11-14T22:13:20.000Z');
+	});
+
+	it('converts epoch 0 and negative epochs blindly (characterized, not endorsed)', () => {
+		expect(parse({ windows: { '5h': { utilization: 0.1, resets_at: 0 } } }).five_hour.resets_at).toBe(
+			'1970-01-01T00:00:00.000Z'
+		);
+		expect(parse({ windows: { '5h': { utilization: 0.1, resets_at: -86400 } } }).five_hour.resets_at).toBe(
+			'1969-12-31T00:00:00.000Z'
+		);
+	});
+
+	it('nulls resets_at when it is not a finite number', () => {
+		expect(parse({ windows: { '5h': { utilization: 0.1, resets_at: '2026-08-15T17:00:00Z' } } }).five_hour.resets_at).toBeNull();
+		expect(parse({ windows: { '5h': { utilization: 0.1, resets_at: Infinity } } }).five_hour.resets_at).toBeNull();
+		expect(parse({ windows: { '5h': { utilization: 0.1 } } }).five_hour.resets_at).toBeNull();
+	});
+
+	it('clamps scaled utilization to [0, 100] and keeps exact 0', () => {
+		expect(parse({ windows: { '5h': { utilization: 1.5 } } }).five_hour.utilization).toBe(100);
+		expect(parse({ windows: { '5h': { utilization: -0.2 } } }).five_hour.utilization).toBe(0);
+		expect(parse({ windows: { '5h': { utilization: 0 } } }).five_hour.utilization).toBe(0);
+	});
+
+	it('drops a window with non-numeric utilization and keeps the other', () => {
+		const out = parse({ windows: { '5h': { utilization: 'x' }, '7d': { utilization: 0.25 } } });
+		expect(out.five_hour).toBeNull();
+		expect(out.seven_day.utilization).toBe(25);
+	});
+
+	it('returns null when windows is missing, non-object, or has no valid window', () => {
+		expect(parse({})).toBeNull();
+		expect(parse(null)).toBeNull();
+		expect(parse({ windows: 'nope' })).toBeNull();
+		expect(parse({ windows: {} })).toBeNull();
+		expect(parse({ windows: { '5h': { utilization: 'x' } } })).toBeNull();
+	});
+});

--- a/tests/tokens-cache.test.js
+++ b/tests/tokens-cache.test.js
@@ -1,0 +1,121 @@
+// Characterization tests for the per-message token cache inside
+// CC.tokens.computeConversationMetrics.
+//
+// The cache only activates when a bridge exposes `requestHash` (the real
+// extension hashes in the page context). Tests stand in for that process
+// boundary with node:crypto — the fake replaces the *other process*, never
+// the unit under test.
+//
+// Cache hits are observed behaviorally, without peeking at internal state:
+// after a first computation, the vendored tokenizer global is removed. A
+// cached message still reports its original count (no re-tokenization); an
+// uncached or changed message drops to 0 (re-tokenization attempted with the
+// tokenizer gone). The tokenizer is restored after each test.
+//
+// This file runs separately from tokens.test.js so its bridge stub and
+// tokenizer manipulation cannot leak into the no-bridge characterization.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
+import { loadContentScripts, makeConversation, textMessage } from './helpers/load.js';
+
+const CC = await loadContentScripts();
+const metrics = (conv) => CC.tokens.computeConversationMetrics(conv);
+
+const realTokenizer = globalThis.GPTTokenizer_o200k_base;
+
+const workingBridge = {
+	requestHash: async (text) => ({ hash: createHash('sha256').update(text).digest('hex') })
+};
+
+beforeEach(() => {
+	CC.bridge = workingBridge;
+});
+
+afterEach(() => {
+	globalThis.GPTTokenizer_o200k_base = realTokenizer;
+	delete CC.bridge;
+});
+
+// "cache me if you can" -> 5 tokens (real o200k count, locked in)
+
+describe('token cache with a working hash bridge', () => {
+	it('serves an unchanged message from cache instead of re-tokenizing', async () => {
+		const conv = makeConversation([textMessage('hit-1', 'cache me if you can')], 'hit-1');
+		expect((await metrics(conv)).totalTokens).toBe(5);
+
+		// Remove the tokenizer: a re-tokenization now yields 0, a cache hit keeps 5.
+		delete globalThis.GPTTokenizer_o200k_base;
+		expect((await metrics(conv)).totalTokens).toBe(5);
+	});
+
+	it('re-tokenizes when a message with the same uuid changes text', async () => {
+		const before = makeConversation([textMessage('changed-1', 'cache me if you can')], 'changed-1');
+		expect((await metrics(before)).totalTokens).toBe(5);
+
+		delete globalThis.GPTTokenizer_o200k_base;
+		const after = makeConversation([textMessage('changed-1', 'cache me if you can, again')], 'changed-1');
+		// Changed fingerprint forces a recount; with the tokenizer gone that recount is 0,
+		// proving the stale 5 was not served.
+		expect((await metrics(after)).totalTokens).toBe(0);
+	});
+
+	it('evicts messages that leave the trunk', async () => {
+		const convA = makeConversation([textMessage('evict-1', 'cache me if you can')], 'evict-1');
+		expect((await metrics(convA)).totalTokens).toBe(5);
+
+		// Computing a different conversation prunes evict-1 from the cache.
+		const convB = makeConversation([textMessage('evict-2', 'hello world')], 'evict-2');
+		expect((await metrics(convB)).totalTokens).toBe(2);
+
+		delete globalThis.GPTTokenizer_o200k_base;
+		expect((await metrics(convA)).totalTokens).toBe(0); // no longer cached
+	});
+
+	it('ignores uuid-less messages entirely — they cannot join the trunk', async () => {
+		// buildTrunk indexes messages by uuid, so a message without one is
+		// unreachable and contributes nothing (its tokens never counted).
+		const conv = makeConversation(
+			[
+				textMessage('haveid-1', 'hello world'),
+				{
+					parent_message_uuid: 'haveid-1',
+					sender: 'human',
+					content: [{ type: 'text', text: 'The quick brown fox jumps over the lazy dog.' }]
+				}
+			],
+			'haveid-1'
+		);
+		const m = await metrics(conv);
+		expect(m.trunkMessageCount).toBe(1);
+		expect(m.totalTokens).toBe(2);
+	});
+});
+
+describe('token cache degradation', () => {
+	it('still counts when the bridge hash request throws', async () => {
+		CC.bridge = {
+			requestHash: async () => {
+				throw new Error('bridge exploded');
+			}
+		};
+		const conv = makeConversation([textMessage('throw-1', 'cache me if you can')], 'throw-1');
+		expect((await metrics(conv)).totalTokens).toBe(5);
+	});
+
+	it('still counts when the bridge returns no hash', async () => {
+		CC.bridge = { requestHash: async () => ({}) };
+		const conv = makeConversation([textMessage('nohash-1', 'cache me if you can')], 'nohash-1');
+		expect((await metrics(conv)).totalTokens).toBe(5);
+	});
+
+	it('does not serve cache hits without a bridge (direct count every time)', async () => {
+		delete CC.bridge;
+		const conv = makeConversation([textMessage('direct-1', 'cache me if you can')], 'direct-1');
+		expect((await metrics(conv)).totalTokens).toBe(5);
+
+		delete globalThis.GPTTokenizer_o200k_base;
+		// No fingerprint -> no cache entry -> recount with missing tokenizer -> 0.
+		expect((await metrics(conv)).totalTokens).toBe(0);
+	});
+});

--- a/tests/tokens.test.js
+++ b/tests/tokens.test.js
@@ -1,0 +1,271 @@
+// Characterization tests for CC.tokens.computeConversationMetrics.
+//
+// All tests feed crafted conversation payloads through the real shipped code,
+// including the real vendored o200k_base tokenizer. Exact token counts below
+// were computed once from that tokenizer and locked in as characterization
+// values:
+//   "hello world"                                   -> 2
+//   "The quick brown fox jumps over the lazy dog."  -> 10
+//   "hello\nworld"                                  -> 3
+//   "attached content"                              -> 2
+//
+// No bridge is present in this file, so the token cache's fingerprint path is
+// inert and every message is counted directly (cache behavior is covered in
+// tokens-cache.test.js).
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { loadContentScripts, makeConversation, makeMessage, textMessage, ROOT_UUID } from './helpers/load.js';
+
+const CC = await loadContentScripts();
+const metrics = (conv) => CC.tokens.computeConversationMetrics(conv);
+
+describe('trunk reconstruction', () => {
+	it('walks leaf-to-root and counts only the active branch, not abandoned siblings', async () => {
+		// root -> A -> B1 (abandoned sibling, 10 tokens)
+		//           -> B2 (active leaf,       2 tokens)
+		const conv = makeConversation(
+			[
+				textMessage('trunk-a', 'The quick brown fox jumps over the lazy dog.'), // parent = ROOT, 10 tokens
+				textMessage('trunk-b1', 'The quick brown fox jumps over the lazy dog.', { parent: 'trunk-a' }), // abandoned sibling
+				textMessage('trunk-b2', 'hello world', { parent: 'trunk-a' }) // active leaf, 2 tokens
+			],
+			'trunk-b2'
+		);
+		const m = await metrics(conv);
+		expect(m.trunkMessageCount).toBe(2); // A + B2, not B1
+		expect(m.totalTokens).toBe(10 + 2); // = 12; including the abandoned sibling would give 22
+	});
+
+	it('returns zero metrics for empty chat_messages', async () => {
+		const m = await metrics(makeConversation([], 'no-such-leaf'));
+		expect(m).toEqual({ trunkMessageCount: 0, totalTokens: 0, lastAssistantMs: null, cachedUntil: null });
+	});
+
+	it('returns zero metrics when current_leaf_message_uuid is missing', async () => {
+		const conv = { chat_messages: [textMessage('lonely-1', 'hello world')] };
+		const m = await metrics(conv);
+		expect(m).toEqual({ trunkMessageCount: 0, totalTokens: 0, lastAssistantMs: null, cachedUntil: null });
+	});
+
+	it('returns zero metrics when the leaf uuid is not among the messages', async () => {
+		const conv = makeConversation([textMessage('present-1', 'hello world')], 'absent-leaf');
+		const m = await metrics(conv);
+		expect(m.trunkMessageCount).toBe(0);
+		expect(m.totalTokens).toBe(0);
+	});
+
+	it('counts a partial trunk when the parent chain breaks mid-walk', async () => {
+		// leaf C -> B -> X (X absent, not ROOT): trunk is [B, C]
+		const conv = makeConversation(
+			[
+				textMessage('orphan-b', 'hello world', { parent: 'orphan-x-missing' }),
+				textMessage('orphan-c', 'hello world', { parent: 'orphan-b' })
+			],
+			'orphan-c'
+		);
+		const m = await metrics(conv);
+		expect(m.trunkMessageCount).toBe(2);
+		expect(m.totalTokens).toBe(4);
+	});
+
+	it('terminates at the all-zeros ROOT uuid', async () => {
+		const conv = makeConversation([textMessage('root-child', 'hello world', { parent: ROOT_UUID })], 'root-child');
+		const m = await metrics(conv);
+		expect(m.trunkMessageCount).toBe(1);
+		expect(m.totalTokens).toBe(2);
+	});
+
+	it('handles non-array chat_messages defensively', async () => {
+		const m = await metrics({ chat_messages: 'not-an-array', current_leaf_message_uuid: 'x' });
+		expect(m.trunkMessageCount).toBe(0);
+		expect(m.totalTokens).toBe(0);
+	});
+
+	// UPSTREAM BUG: buildTrunk has no cycle guard / visited set. A parent
+	// chain A -> B -> A never reaches ROOT and never breaks, so the
+	// synchronous walk loops forever. The probe runs in a child process
+	// (killed after 2s) because a busy sync loop can't be interrupted by an
+	// in-process timeout. This test characterizes the buggy behavior
+	// directly: it fails loudly if the harness breaks AND when the bug is
+	// fixed (a one-line visited-set fix). When fixing the bug, flip these
+	// assertions to expect DONE and a clean exit.
+	it('UPSTREAM BUG: hangs on a cyclic parent chain (probe killed by timeout)', () => {
+		const probe = fileURLToPath(new URL('./helpers/cycle-probe.cjs', import.meta.url));
+		const res = spawnSync(process.execPath, [probe], { timeout: 2000, encoding: 'utf8' });
+		expect(res.stderr).not.toMatch(/Error/); // probe loaded cleanly — not a harness crash
+		expect(res.stdout).not.toContain('DONE'); // the walk never terminated
+		expect(res.signal).toBe('SIGTERM'); // killed by spawnSync's timeout
+	}, 10000);
+});
+
+describe('countable-content rules', () => {
+	it('gives zero tokens for thinking, redacted_thinking, image, and document blocks', async () => {
+		const conv = makeConversation(
+			[
+				makeMessage({
+					uuid: 'uncounted-1',
+					content: [
+						{ type: 'thinking', thinking: 'The quick brown fox jumps over the lazy dog.' },
+						{ type: 'redacted_thinking', data: 'The quick brown fox jumps over the lazy dog.' },
+						{ type: 'image', source: { data: 'aGVsbG8gd29ybGQ=' } },
+						{ type: 'document', title: 'The quick brown fox' }
+					]
+				})
+			],
+			'uncounted-1'
+		);
+		const m = await metrics(conv);
+		expect(m.trunkMessageCount).toBe(1);
+		expect(m.totalTokens).toBe(0);
+	});
+
+	it('counts text blocks; multiple blocks in one message join with a newline', async () => {
+		// "hello" + "world" joined -> "hello\nworld" -> 3 tokens (not 2+2)
+		const twoBlocks = makeConversation(
+			[
+				makeMessage({
+					uuid: 'join-two',
+					content: [
+						{ type: 'text', text: 'hello' },
+						{ type: 'text', text: 'world' }
+					]
+				})
+			],
+			'join-two'
+		);
+		const oneBlock = makeConversation([textMessage('join-one', 'hello\nworld')], 'join-one');
+		const mTwo = await metrics(twoBlocks);
+		const mOne = await metrics(oneBlock);
+		expect(mTwo.totalTokens).toBe(3);
+		expect(mTwo.totalTokens).toBe(mOne.totalTokens);
+	});
+
+	it('serializes tool_use deterministically regardless of key insertion order', async () => {
+		const inputAB = { alpha: 1, beta: { gamma: 'g', delta: 'd' } };
+		const inputBA = { beta: { delta: 'd', gamma: 'g' }, alpha: 1 };
+		const toolConv = (uuid, input) =>
+			makeConversation(
+				[makeMessage({ uuid, content: [{ type: 'tool_use', id: 'toolu_01', name: 'calculator', input }] })],
+				uuid
+			);
+		const mAB = await metrics(toolConv('tool-order-ab', inputAB));
+		const mBA = await metrics(toolConv('tool-order-ba', inputBA));
+		expect(mAB.totalTokens).toBeGreaterThan(0);
+		expect(mAB.totalTokens).toBe(mBA.totalTokens);
+	});
+
+	it('serializes tool_result deterministically regardless of key insertion order', async () => {
+		const contentAB = [{ type: 'text', text: 'result' }];
+		const resultConv = (uuid, block) => makeConversation([makeMessage({ uuid, content: [block] })], uuid);
+		const mAB = await metrics(
+			resultConv('toolres-ab', { type: 'tool_result', tool_use_id: 'toolu_01', is_error: false, content: contentAB })
+		);
+		const mBA = await metrics(
+			resultConv('toolres-ba', { content: contentAB, is_error: false, tool_use_id: 'toolu_01', type: 'tool_result' })
+		);
+		expect(mAB.totalTokens).toBeGreaterThan(0);
+		expect(mAB.totalTokens).toBe(mBA.totalTokens);
+	});
+
+	it('does not throw on tool_use with a circular input object', async () => {
+		const input = { name: 'loop' };
+		input.self = input;
+		const conv = makeConversation(
+			[makeMessage({ uuid: 'tool-circular', content: [{ type: 'tool_use', id: 'toolu_02', name: 'looper', input }] })],
+			'tool-circular'
+		);
+		const m = await metrics(conv);
+		expect(m.totalTokens).toBeGreaterThan(0); // serialized with a [Circular] placeholder, still counted
+	});
+
+	it('counts attachment extracted_content', async () => {
+		const conv = makeConversation(
+			[makeMessage({ uuid: 'attach-1', content: [], attachments: [{ file_name: 'a.txt', extracted_content: 'attached content' }] })],
+			'attach-1'
+		);
+		const m = await metrics(conv);
+		expect(m.totalTokens).toBe(2);
+	});
+
+	it('treats non-array message content as empty', async () => {
+		const conv = makeConversation([makeMessage({ uuid: 'badcontent-1', content: 'not an array' })], 'badcontent-1');
+		const m = await metrics(conv);
+		expect(m.trunkMessageCount).toBe(1);
+		expect(m.totalTokens).toBe(0);
+	});
+});
+
+describe('token counting with the real o200k tokenizer', () => {
+	it('produces stable exact counts for known strings', async () => {
+		const m1 = await metrics(makeConversation([textMessage('exact-1', 'hello world')], 'exact-1'));
+		expect(m1.totalTokens).toBe(2);
+		const m2 = await metrics(
+			makeConversation([textMessage('exact-2', 'The quick brown fox jumps over the lazy dog.')], 'exact-2')
+		);
+		expect(m2.totalTokens).toBe(10);
+	});
+
+	it('counts empty or missing text as zero', async () => {
+		const conv = makeConversation(
+			[
+				textMessage('empty-1', ''),
+				makeMessage({ uuid: 'empty-2', parent: 'empty-1', content: [{ type: 'text' }] })
+			],
+			'empty-2'
+		);
+		const m = await metrics(conv);
+		expect(m.trunkMessageCount).toBe(2);
+		expect(m.totalTokens).toBe(0);
+	});
+});
+
+describe('cache-window math', () => {
+	const T1 = '2026-08-15T12:00:00.000Z';
+	const T2 = '2026-08-15T12:10:00.000Z';
+	const FIVE_MIN = 5 * 60 * 1000;
+
+	it('sets cachedUntil to the last assistant created_at plus five minutes', async () => {
+		const conv = makeConversation(
+			[
+				textMessage('cw-h1', 'hello world'),
+				textMessage('cw-a1', 'hello world', { parent: 'cw-h1', sender: 'assistant', created_at: T1 })
+			],
+			'cw-a1'
+		);
+		const m = await metrics(conv);
+		expect(m.lastAssistantMs).toBe(Date.parse(T1));
+		expect(m.cachedUntil).toBe(Date.parse(T1) + FIVE_MIN);
+	});
+
+	it('returns null cachedUntil for a user-only conversation', async () => {
+		const conv = makeConversation([textMessage('cw-solo', 'hello world', { created_at: T1 })], 'cw-solo');
+		const m = await metrics(conv);
+		expect(m.lastAssistantMs).toBeNull();
+		expect(m.cachedUntil).toBeNull();
+	});
+
+	it('picks the latest of multiple assistant messages regardless of trunk order', async () => {
+		// Later assistant (T2) sits earlier in the trunk than the T1 assistant.
+		const conv = makeConversation(
+			[
+				textMessage('cw-m1', 'hello world', { sender: 'assistant', created_at: T2 }),
+				textMessage('cw-m2', 'hello world', { parent: 'cw-m1' }),
+				textMessage('cw-m3', 'hello world', { parent: 'cw-m2', sender: 'assistant', created_at: T1 })
+			],
+			'cw-m3'
+		);
+		const m = await metrics(conv);
+		expect(m.lastAssistantMs).toBe(Date.parse(T2));
+		expect(m.cachedUntil).toBe(Date.parse(T2) + FIVE_MIN);
+	});
+});
+
+describe('operation without a bridge', () => {
+	it('still counts tokens when CC.bridge is absent (hashing unavailable)', async () => {
+		expect(CC.bridge).toBeUndefined(); // node env: bridge-client.js is not loaded here
+		const m = await metrics(makeConversation([textMessage('nobridge-1', 'hello world')], 'nobridge-1'));
+		expect(m.totalTokens).toBe(2);
+	});
+});

--- a/tests/tokens.test.js
+++ b/tests/tokens.test.js
@@ -83,20 +83,17 @@ describe('trunk reconstruction', () => {
 		expect(m.totalTokens).toBe(0);
 	});
 
-	// UPSTREAM BUG: buildTrunk has no cycle guard / visited set. A parent
-	// chain A -> B -> A never reaches ROOT and never breaks, so the
-	// synchronous walk loops forever. The probe runs in a child process
-	// (killed after 2s) because a busy sync loop can't be interrupted by an
-	// in-process timeout. This test characterizes the buggy behavior
-	// directly: it fails loudly if the harness breaks AND when the bug is
-	// fixed (a one-line visited-set fix). When fixing the bug, flip these
-	// assertions to expect DONE and a clean exit.
-	it('UPSTREAM BUG: hangs on a cyclic parent chain (probe killed by timeout)', () => {
+	// Regression guard: buildTrunk originally had no cycle guard, so a
+	// parent chain A -> B -> A looped forever (found by probing; fixed with
+	// a visited set). The probe still runs in a child process killed after
+	// 2s, because a regression would reintroduce a busy synchronous loop
+	// that no in-process timeout can interrupt.
+	it('terminates when the parent chain contains a cycle', () => {
 		const probe = fileURLToPath(new URL('./helpers/cycle-probe.cjs', import.meta.url));
 		const res = spawnSync(process.execPath, [probe], { timeout: 2000, encoding: 'utf8' });
 		expect(res.stderr).not.toMatch(/Error/); // probe loaded cleanly — not a harness crash
-		expect(res.stdout).not.toContain('DONE'); // the walk never terminated
-		expect(res.signal).toBe('SIGTERM'); // killed by spawnSync's timeout
+		expect(res.stdout).toContain('DONE');
+		expect(res.status).toBe(0);
 	}, 10000);
 });
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,6 +5,10 @@ export default defineConfig({
 		// Default to plain node; DOM-touching test files opt in via
 		// a `// @vitest-environment jsdom` pragma at the top of the file.
 		environment: 'node',
+		// tokens.test.js and tokens-cache.test.js rely on per-file module
+		// registries: the token cache in src/content/tokens.js is a module
+		// singleton. Pin isolation so a future speed tweak can't break that.
+		isolate: true,
 		include: ['tests/**/*.test.js']
 	}
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// Default to plain node; DOM-touching test files opt in via
+		// a `// @vitest-environment jsdom` pragma at the top of the file.
+		environment: 'node',
+		include: ['tests/**/*.test.js']
+	}
+});


### PR DESCRIPTION
Hi — I'm the author of #41 (the copycat-repo report). While putting that report together I ended up reading this codebase in full, and the logic core (trunk reconstruction, token counting, cache math, usage parsing, the postMessage bridge) turned out to be pure and very testable. This PR adds a behavioral test suite for it: **47 tests, all green**, `npm ci && npm test` from a bare clone.

## Approach

These are **characterization tests**: written from reading the code and README, then locked in against current behavior. They exercise the real shipped files — including the real vendored o200k tokenizer, with exact token counts asserted — through the public `ClaudeCounter.*` surface. The only fakes stand in for process boundaries (the page side of `postMessage`; `node:crypto` for the injected script's hash service). No test asserts internal state or call counts, so refactors that preserve behavior won't break them.

The sources stay browser-first: no bundler, no module conversion. Tests load the IIFEs by side-effect import in manifest order.

## Commit-by-commit (cherry-pickable — happy to drop any of these)

1. **`chore: add vitest test scaffolding`** — `package.json` (dev-only deps: vitest + jsdom, exact-pinned), `vitest.config.js`, `.gitignore` entry. No runtime changes.
2. **`test: characterization suite`** — 35 tests for `tokens.js` (trunk walk, countable-content rules, exact o200k counts, cache-window math, the per-message token cache observed behaviorally) and `bridge-client.js` (request/response, timeout, marker/source/request-id filtering, events). **Touches no shipped file.**
3. **`refactor: expose usage parsers as CC.parsers`** — moves `parseUsageFromUsageEndpoint` / `parseUsageFromMessageLimit` verbatim from `main.js` (which can't be imported in tests — it starts observers on load) into `src/content/parsers.js`, +12 tests: clamping, 0-is-valid, window dropping, `resets_at` handling, 5h/7d mapping, epoch→ISO conversion. `manifest.json` loads it before `main.js`. The userscript build is self-contained and untouched. *Drop this commit if you'd rather not touch shipped files; only `tests/parsers.test.js` fails without it.*
4. **`ci: run the test suite on push and pull request`** — GitHub Actions, Node 22/24. *Drop if you don't want CI.*
5. **`fix: guard buildTrunk against cycles in the parent chain`** — one bug found by deliberate probing: a `parent_message_uuid` cycle (A → B → A) never reaches the ROOT sentinel, so the synchronous walk loops forever and freezes the tab. A visited set terminates it. The cycle test asserts termination; *if you drop this commit, flip that test's assertions back to document the hang (comments in the test explain how). The probe runs in a killable child process because a busy sync loop can't be interrupted in-process.*

## Notes / observations

- **Node ≥ 22** is required for the dev tooling (jsdom 30's floor). Runtime is unaffected.
- `src/vendor/o200k_base.js` references `o200k_base.js.map`, which isn't vendored — vite logs a benign ENOENT warning during test runs. Left alone rather than editing a vendored file.
- The `: countTokens(msgText)` fallback in `computeConversationMetrics` is unreachable: uuid-less messages never enter the trunk (`buildTrunk` indexes by uuid). Just an observation — not changed.
- Deliberately out of scope: `main.js` orchestration and `ui.js` DOM injection (brittle against claude.ai markup), the injected `bridge.js` fetch-patching, and `ui.js`'s `formatSeconds`/`formatResetCountdown` (would need a small `CC.format` refactor — happy to follow up if wanted).

If you'd like this split differently, or want only a subset, say the word and I'll rework the branch.
